### PR TITLE
Make Stargazer bg image fully touch edges of profile card

### DIFF
--- a/Valour/Client/Components/Users/ProfileCard.razor.css
+++ b/Valour/Client/Components/Users/ProfileCard.razor.css
@@ -49,6 +49,7 @@
     background-color: var(--main-1);
     height: 100%;
     width: 100%;
+    overflow: hidden;
 }
 
 .inner-card > * {
@@ -189,7 +190,6 @@
     height: 100%;
     width: 100%;
     filter: brightness(0.4);
-    border-radius: 30px;
 }
 
 .last-active {


### PR DESCRIPTION
<p float="left">
    <img src="https://github.com/Valour-Software/Valour/assets/90942493/4303d05c-a933-4272-85d7-cf16d35f95b3"> 
    <img src="https://github.com/Valour-Software/Valour/assets/90942493/8a08e064-4838-431b-a1cf-4c8457e0ce8a">

<sup>Left: before, you can see that the background image does not meet the corners

</p>
