### PR TITLE
Modify .smooth-drag z-index to fix overlay on bigmenu-section

### DIFF
--- a/Valour/Client/Components/Utility/SmoothDraggable.razor.css
+++ b/Valour/Client/Components/Utility/SmoothDraggable.razor.css
@@ -1,4 +1,4 @@
 .smooth-drag {
     position: absolute;
-    z-index: 100;
+    z-index: 99; /* Changing 100 -> 99 fixes overlay from bigmenu-section*/
 }


### PR DESCRIPTION
Modified the z-index on the .smooth-drag in `SmothDraggable.razor.css` from 100 to 99 to fix the "Watching" menu overlaying on the user settings menu