### PR TITLE
Update roles after creating new role or deleting an existing one

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditRoles/EditPlanetRolesComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditRoles/EditPlanetRolesComponent.razor
@@ -501,6 +501,7 @@
             if (creating)
             {
                 _editMode = false;
+                _roles.Add(_role);
                 _roleMemberCounts[_role.Id] = 0;
             }
         }

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditRoles/EditPlanetRolesComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditRoles/EditPlanetRolesComponent.razor
@@ -411,10 +411,14 @@
             "Cancel",
             async () => {
                 _result = await _selected.Node.DeleteAsync($"api/roles/{role.Id.ToString()}");
+                _editMode = false;
                 StateHasChanged();
             },
             () =>
             {
+                // without setting _editMode to false, it remains in the delete screen after canceling 
+                // the user then has to navigate to another setting, then back to roles to access the roles list again
+                _editMode = false;
                 StateHasChanged();
                 return Task.CompletedTask;
             }


### PR DESCRIPTION
New roles show up in the roles list after creation.
Deleting a role navigates back to the roles planet setting.
Hitting the cancel button in the delete role screen navigates back to the roles planet setting.