### PR TITLE
Patch vulnerable dependency

### DIFF
--- a/Valour/Client/Valour.Client.csproj
+++ b/Valour/Client/Valour.Client.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.1" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
     <PackageReference Include="Valour.Markdig.Blazor" Version="1.0.0" />
     <PackageReference Include="Valour.TenorTwo" Version="1.0.0" />
   </ItemGroup>

--- a/Valour/Server/Valour.Server.csproj
+++ b/Valour/Server/Valour.Server.csproj
@@ -22,7 +22,7 @@
     <PackageReference Include="SendGrid" Version="9.29.1" />
     <PackageReference Include="Sentry" Version="4.0.0" />
     <PackageReference Include="Sentry.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.2" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.3" />
     <PackageReference Include="StackExchange.Redis" Version="2.7.17" />
     <PackageReference Include="Swashbuckle" Version="5.6.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />


### PR DESCRIPTION
Patches `CVE-2024-27929` on Valour by upgrading ImageSharp from 3.1.2 -> 3.1.3