### PR TITLE
Fix mismatched route parameters

### DIFF
--- a/Valour/Server/Api/Dynamic/OauthAppApi.cs
+++ b/Valour/Server/Api/Dynamic/OauthAppApi.cs
@@ -8,11 +8,15 @@ public class OauthAppAPI
     [ValourRoute(HttpVerbs.Put, "api/oauthapps/{id}")]
     [UserRequired(UserPermissionsEnum.FullControl)]
     public static async Task<IResult> PutRouteAsync(
-        [FromBody] OauthApp app, 
+        [FromBody] OauthApp app,
+        long id,
         OauthAppService oauthAppService,
         UserService userService)
     {
         var userId = await userService.GetCurrentUserIdAsync();
+
+        if (app.Id != id)
+            return ValourResult.BadRequest("Route id does not match app id");
 
         var old = await oauthAppService.GetAsync(app.Id);
 

--- a/Valour/Server/Api/Dynamic/PlanetInviteApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetInviteApi.cs
@@ -48,11 +48,15 @@ public class PlanetInviteApi
     [UserRequired(UserPermissionsEnum.PlanetManagement)]
     public static async Task<IResult> PutRouteAsync(
         [FromBody] PlanetInvite invite,
+        long id,
         PlanetMemberService memberService,
         PlanetInviteService inviteService)
     {
         if (invite is null)
             return ValourResult.BadRequest("Include invite in body.");
+
+        if (invite.Id != id)
+            return ValourResult.BadRequest("Route id does not match invite id.");
 
         // Get member
         var member = await memberService.GetCurrentAsync(invite.PlanetId);

--- a/Valour/Server/Api/Dynamic/SubscriptionApi.cs
+++ b/Valour/Server/Api/Dynamic/SubscriptionApi.cs
@@ -4,7 +4,7 @@ namespace Valour.Server.Api.Dynamic;
 
 public class SubscriptionApi
 {
-    [ValourRoute(HttpVerbs.Get, "api/subscriptions/active/{userId}")]
+    [ValourRoute(HttpVerbs.Get, "api/subscriptions/active")]
     [UserRequired(UserPermissionsEnum.FullControl)]
     public static async Task<IResult> GetActiveAsync(
         UserService userService, 

--- a/Valour/Server/Api/Dynamic/UserApi.cs
+++ b/Valour/Server/Api/Dynamic/UserApi.cs
@@ -55,10 +55,14 @@ public class UserApi
     [ValourRoute(HttpVerbs.Put, "api/users/{id}")]
     [UserRequired(UserPermissionsEnum.FullControl)]
     public static async Task<IResult> PutRouteAsync(
-        [FromBody] User user, 
+        [FromBody] User user,
+        long id,
         UserService userService)
     {
         var currentUser = await userService.GetCurrentUserAsync();
+
+        if (user.Id != id)
+            return ValourResult.BadRequest("Route id does not match user id");
 
         // Unlike most other entities, we are just copying over a few fields here and
         // ignoring the rest. There are so many things that *should not* be touched by

--- a/Valour/Server/Api/OauthAPI.cs
+++ b/Valour/Server/Api/OauthAPI.cs
@@ -20,7 +20,7 @@ public class OauthAPI : BaseAPI
         app.MapDelete("api/oauth/app/{app_id}", DeleteApp);
         app.MapGet("api/oauth/app/public/{app_id}", GetAppPublic);
 
-        app.MapGet("api/users/{userId}/apps", GetApps);
+        app.MapGet("api/users/apps", GetApps);
 
         app.MapPost("api/oauth/authorize", Authorize);
         app.MapGet("api/oauth/token", Token);


### PR DESCRIPTION
## Summary
- fix `api/users/apps` route so it doesn't require a userId parameter
- ensure PUT APIs validate path ids for `OauthAppApi`, `PlanetInviteApi`, and `UserApi`
- clean up subscription API route

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: `dotnet` command not found)*