### PR TITLE
Implement query engine for planet members and bans

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetBansComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetBansComponent.razor
@@ -14,7 +14,7 @@
         </tr>
     </thead>
     <tbody>
-        @if (Planet?.Bans is null || Planet.Bans.Count == 0)
+        @if (_banCount == 0)
         {
             <tr class="empty-row">
                 <td colspan="5">
@@ -27,7 +27,7 @@
         }
         else
         {
-            <Virtualize Items="Planet.Bans" Context="ban">
+            <Virtualize TItem="PlanetBan" ItemsProvider="@_banEngine.GetVirtualizedItemsAsync" Context="ban" OverscanCount="20">
                 <tr @key="ban.Id">
                     <td><UserInfoComponent UserId="@ban.TargetId" /></td>
                     <td><UserInfoComponent UserId="@ban.IssuerId" /></td>
@@ -55,10 +55,15 @@
     public ModalRoot ModalRoot { get; set; }
 
     private ITaskResult _result;
+    private ModelQueryEngine<PlanetBan> _banEngine;
+    private int _banCount = 0;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         Planet ??= WindowService.FocusedPlanet;
+        _banEngine = Planet.GetBanQueryEngine();
+        var info = await _banEngine.GetItemsAsync(0, 1);
+        _banCount = info.TotalCount;
     }
 
     private void OnEdit(PlanetBan ban)

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
@@ -12,7 +12,7 @@
         </tr>
     </thead>
     <tbody>
-        @if (Planet?.Members is null || Planet.Members.Count == 0)
+        @if (_memberCount == 0)
         {
             <tr class="empty-row">
                 <td colspan="3">
@@ -25,7 +25,7 @@
         }
         else
         {
-            <Virtualize Items="Planet.Members" Context="member">
+            <Virtualize TItem="PlanetMember" ItemsProvider="@_memberEngine.GetVirtualizedItemsAsync" Context="member" OverscanCount="20">
                 <tr @key="member.Id">
                     <td><UserInfoComponent Member="@member" /></td>
                     <td>@member.PrimaryRole?.Name</td>
@@ -48,12 +48,16 @@
     [CascadingParameter]
     public ModalRoot ModalRoot { get; set; }
 
+    private ModelQueryEngine<PlanetMember> _memberEngine;
+    private int _memberCount = 0;
+
     protected override async Task OnInitializedAsync()
     {
         Planet ??= WindowService.FocusedPlanet;
 
-        if (Planet.Members.Count == 0)
-            await Planet.FetchMemberDataAsync();
+        _memberEngine = Planet.GetMemberQueryEngine();
+        var info = await _memberEngine.GetItemsAsync(0, 1);
+        _memberCount = info.TotalCount;
     }
 
     private void OnKick(PlanetMember member)

--- a/Valour/Sdk/Models/Planet.cs
+++ b/Valour/Sdk/Models/Planet.cs
@@ -589,6 +589,12 @@ public class Planet : ClientModel<Planet, long>, ISharedPlanet, IDisposable
     
     public ModelQueryEngine<EcoAccountPlanetMember> GetUserAccountQueryEngine() =>
         Client.EcoService.GetUserAccountQueryEngine(this);
+
+    public ModelQueryEngine<PlanetMember> GetMemberQueryEngine() =>
+        Client.PlanetService.GetMemberQueryEngine(this);
+
+    public ModelQueryEngine<PlanetBan> GetBanQueryEngine() =>
+        Client.PlanetService.GetBanQueryEngine(this);
     
     public string GetIconUrl(IconFormat format = IconFormat.Webp256) =>
         ISharedPlanet.GetIconUrl(this, format);

--- a/Valour/Sdk/Services/PlanetService.cs
+++ b/Valour/Sdk/Services/PlanetService.cs
@@ -7,6 +7,7 @@ using Valour.Sdk.Nodes;
 using Valour.Shared;
 using Valour.Shared.Models;
 using Valour.Shared.Utilities;
+using Valour.Sdk.Models;
 
 namespace Valour.Sdk.Services;
 
@@ -528,6 +529,12 @@ public class PlanetService : ServiceBase
         var planet = await FetchPlanetAsync(planetId, skipCache);
         return await planet.Node.DeleteAsync($"api/planets/{planetId}/members/{memberId}/roles/{roleId}");
     }
+
+    public ModelQueryEngine<PlanetMember> GetMemberQueryEngine(Planet planet) =>
+        new ModelQueryEngine<PlanetMember>(planet.Node, $"api/planets/{planet.Id}/members");
+
+    public ModelQueryEngine<PlanetBan> GetBanQueryEngine(Planet planet) =>
+        new ModelQueryEngine<PlanetBan>(planet.Node, $"api/planets/{planet.Id}/bans");
     
     private void OnRoleOrderUpdate(RoleOrderEvent e)
     {

--- a/Valour/Server/Api/Dynamic/PlanetApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetApi.cs
@@ -193,6 +193,26 @@ public class PlanetApi
         return Results.Json(memberInfo);
     }
 
+    [ValourRoute(HttpVerbs.Get, "api/planets/{id}/members")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> GetMembersRouteAsync(
+        long id,
+        PlanetMemberService memberService,
+        int skip = 0,
+        int take = 50)
+    {
+        var member = await memberService.GetCurrentAsync(id);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        var members = await memberService.QueryPlanetMembersAsync(id, skip, take);
+
+        return Results.Json(members);
+    }
+
     [ValourRoute(HttpVerbs.Get, "api/planets/{id}/roles")]
     [UserRequired(UserPermissionsEnum.Membership)]
     public static async Task<IResult> GetRolesRouteAsync(
@@ -332,6 +352,27 @@ public class PlanetApi
 
         var inviteIds = await planetService.GetInviteIdsAsync(id);
         return Results.Json(inviteIds);
+    }
+
+    [ValourRoute(HttpVerbs.Get, "api/planets/{id}/bans")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> GetBansRouteAsync(
+        long id,
+        PlanetMemberService memberService,
+        PlanetBanService banService,
+        int skip = 0,
+        int take = 50)
+    {
+        var member = await memberService.GetCurrentAsync(id);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        var bans = await banService.QueryPlanetBansAsync(id, skip, take);
+
+        return Results.Json(bans);
     }
 
     [ValourRoute(HttpVerbs.Get, "api/planets/discoverable")]

--- a/Valour/Server/Services/PlanetBanService.cs
+++ b/Valour/Server/Services/PlanetBanService.cs
@@ -118,6 +118,31 @@ public class PlanetBanService
         return new(true, "Success", updatedban);
     }
 
+    public async Task<QueryResponse<PlanetBan>> QueryPlanetBansAsync(long planetId, int skip = 0, int take = 50)
+    {
+        if (take > 50)
+            take = 50;
+
+        var baseQuery = _db.PlanetBans
+            .AsNoTracking()
+            .Where(x => x.PlanetId == planetId)
+            .OrderByDescending(x => x.TimeCreated);
+
+        var total = await baseQuery.CountAsync();
+
+        var items = await baseQuery
+            .Skip(skip)
+            .Take(take)
+            .Select(x => x.ToModel())
+            .ToListAsync();
+
+        return new QueryResponse<PlanetBan>
+        {
+            Items = items,
+            TotalCount = total
+        };
+    }
+
     /// <summary>
     /// Deletes the ban
     /// </summary>

--- a/Valour/Server/Services/PlanetMemberService.cs
+++ b/Valour/Server/Services/PlanetMemberService.cs
@@ -193,6 +193,32 @@ public class PlanetMemberService
         return await _permissionService.HasPlanetPermissionAsync(member.Id, permission);
     }
 
+    public async Task<QueryResponse<PlanetMember>> QueryPlanetMembersAsync(long planetId, int skip = 0, int take = 50)
+    {
+        if (take > 50)
+            take = 50;
+
+        var baseQuery = _db.PlanetMembers
+            .AsNoTracking()
+            .Include(x => x.User)
+            .Where(x => x.PlanetId == planetId && !x.IsDeleted)
+            .OrderBy(x => x.Id);
+
+        var total = await baseQuery.CountAsync();
+
+        var items = await baseQuery
+            .Skip(skip)
+            .Take(take)
+            .Select(x => x.ToModel())
+            .ToListAsync();
+
+        return new QueryResponse<PlanetMember>
+        {
+            Items = items,
+            TotalCount = total
+        };
+    }
+
     /// <summary>
     /// Returns if the member has the given channel permission
     /// </summary>


### PR DESCRIPTION
## Summary
- add query endpoints for planet members and bans
- add query helpers in `PlanetService` and `Planet` model
- virtualize Edit Members and Edit Bans lists

## Testing
- `dotnet test` *(fails: `dotnet: command not found`)*