### PR TITLE
Unify planet editor tables

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetBansComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetBansComponent.razor
@@ -3,47 +3,12 @@
 <h3>Bans <i class="bi bi-shield-fill-exclamation"></i></h3>
 <p class="subtitle">MANAGE BANS</p>
 
-<table class="v-table">
-    <thead>
-        <tr>
-            <th>User</th>
-            <th>Banned By</th>
-            <th>Created</th>
-            <th>Expires</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        @if (_banCount == 0)
-        {
-            <tr class="empty-row">
-                <td colspan="5">
-                    <div class="empty-state">
-                        <i class="bi bi-hammer"></i>
-                        <span>No bans</span>
-                    </div>
-                </td>
-            </tr>
-        }
-        else
-        {
-            <Virtualize TItem="PlanetBan" ItemsProvider="@_banEngine.GetVirtualizedItemsAsync" Context="ban" OverscanCount="20">
-                <tr @key="ban.Id">
-                    <td><UserInfoComponent UserId="@ban.TargetId" /></td>
-                    <td><UserInfoComponent UserId="@ban.IssuerId" /></td>
-                    <td>@ban.TimeCreated.ToLocalTime().ToShortDateString()</td>
-                    <td>@(ban.Permanent ? "Never" : ban.TimeExpires?.ToLocalTime().ToShortDateString())</td>
-                    <td>
-                        <div class="button-row">
-                            <button class="v-btn secondary" @onclick="(() => OnEdit(ban))">Edit</button>
-                            <button class="v-btn danger" @onclick="(() => OnDelete(ban))">Delete</button>
-                        </div>
-                    </td>
-                </tr>
-            </Virtualize>
-        }
-    </tbody>
-</table>
+<QueryTable
+    @ref="_table"
+    Node="@Planet.Node"
+    TModel="PlanetBan"
+    Columns="@_columns"
+    Model="@_model" />
 
 <ResultLabel Result="@_result" />
 
@@ -55,15 +20,47 @@
     public ModalRoot ModalRoot { get; set; }
 
     private ITaskResult _result;
-    private ModelQueryEngine<PlanetBan> _banEngine;
-    private int _banCount = 0;
-
-    protected override async Task OnInitializedAsync()
+    private QueryTable<PlanetBan> _table;
+    private List<ColumnDefinition<PlanetBan>> _columns;
+    private PlanetBanQueryModel _model;
+    protected override void OnInitialized()
     {
         Planet ??= WindowService.FocusedPlanet;
-        _banEngine = Planet.GetBanQueryEngine();
-        var info = await _banEngine.GetItemsAsync(0, 1);
-        _banCount = info.TotalCount;
+        _model = new PlanetBanQueryModel { PlanetId = Planet.Id };
+
+        _columns = new()
+        {
+            new()
+            {
+                Name = "User",
+                SortField = "user",
+                RenderFragment = row => @<UserInfoComponent UserId="@row.Row.TargetId" />
+            },
+            new()
+            {
+                Name = "Banned By",
+                RenderFragment = row => @<UserInfoComponent UserId="@row.Row.IssuerId" />
+            },
+            new()
+            {
+                Name = "Created",
+                SortField = "created",
+                RenderFragment = row => @<span>@row.Row.TimeCreated.ToLocalTime().ToShortDateString()</span>
+            },
+            new()
+            {
+                Name = "Expires",
+                RenderFragment = row => @<span>@(row.Row.Permanent ? "Never" : row.Row.TimeExpires?.ToLocalTime().ToShortDateString())</span>
+            },
+            new()
+            {
+                Name = "Actions",
+                RenderFragment = row => @<div class="button-row">
+                        <button class="v-btn secondary" @onclick="(() => OnEdit(row.Row))">Edit</button>
+                        <button class="v-btn danger" @onclick="(() => OnDelete(row.Row))">Delete</button>
+                    </div>
+            }
+        };
     }
 
     private void OnEdit(PlanetBan ban)

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
@@ -3,43 +3,14 @@
 <h3>Members <i class="bi bi-person-fill"></i></h3>
 <p class="subtitle">MANAGE MEMBERS</p>
 
-<table class="v-table">
-    <thead>
-        <tr>
-            <th>Member</th>
-            <th>Role</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-        @if (_memberCount == 0)
-        {
-            <tr class="empty-row">
-                <td colspan="3">
-                    <div class="empty-state">
-                        <i class="bi bi-people"></i>
-                        <span>No members</span>
-                    </div>
-                </td>
-            </tr>
-        }
-        else
-        {
-            <Virtualize TItem="PlanetMember" ItemsProvider="@_memberEngine.GetVirtualizedItemsAsync" Context="member" OverscanCount="20">
-                <tr @key="member.Id">
-                    <td><UserInfoComponent Member="@member" /></td>
-                    <td>@member.PrimaryRole?.Name</td>
-                    <td>
-                        <div class="button-row">
-                            <button class="v-btn secondary" @onclick="(() => OnKick(member))">Kick</button>
-                            <button class="v-btn danger" @onclick="(() => OnBan(member))">Ban</button>
-                        </div>
-                    </td>
-                </tr>
-            </Virtualize>
-        }
-    </tbody>
-</table>
+<QueryTable
+    @ref="_table"
+    Node="@Planet.Node"
+    TModel="PlanetMember"
+    Columns="@_columns"
+    Model="@_model"
+    ShowSearch="true"
+    SearchPlaceholder="Search name..." />
 
 @code {
     [Parameter]
@@ -48,16 +19,37 @@
     [CascadingParameter]
     public ModalRoot ModalRoot { get; set; }
 
-    private ModelQueryEngine<PlanetMember> _memberEngine;
-    private int _memberCount = 0;
+    private QueryTable<PlanetMember> _table;
+    private List<ColumnDefinition<PlanetMember>> _columns;
+    private PlanetMemberQueryModel _model;
 
-    protected override async Task OnInitializedAsync()
+    protected override void OnInitialized()
     {
         Planet ??= WindowService.FocusedPlanet;
+        _model = new PlanetMemberQueryModel { PlanetId = Planet.Id };
 
-        _memberEngine = Planet.GetMemberQueryEngine();
-        var info = await _memberEngine.GetItemsAsync(0, 1);
-        _memberCount = info.TotalCount;
+        _columns = new()
+        {
+            new()
+            {
+                Name = "Member",
+                SortField = "name",
+                RenderFragment = row => @<UserInfoComponent Member="@row.Row" />
+            },
+            new()
+            {
+                Name = "Role",
+                RenderFragment = row => @<span>@row.Row.PrimaryRole?.Name</span>
+            },
+            new()
+            {
+                Name = "Actions",
+                RenderFragment = row => @<div class="button-row">
+                        <button class="v-btn secondary" @onclick="(() => OnKick(row.Row))">Kick</button>
+                        <button class="v-btn danger" @onclick="(() => OnBan(row.Row))">Ban</button>
+                    </div>
+            }
+        };
     }
 
     private void OnKick(PlanetMember member)

--- a/Valour/Client/Components/Utility/QueryTable.razor
+++ b/Valour/Client/Components/Utility/QueryTable.razor
@@ -14,12 +14,23 @@
     return;
 }
 
+@if (ShowSearch)
+{
+    <input class="form-control mt-2 mb-2" placeholder="@SearchPlaceholder" @onchange="OnSearchChanged" />
+}
+
 <table class="table">
     <thead>
     <tr>
         @foreach (var column in Columns)
         {
-            <th>@column.Name</th>
+            <th @onclick="(() => OnSort(column))" style="cursor:pointer">
+                @column.Name
+                @if (_sortField == column.SortField)
+                {
+                    <i class="bi bi-caret-@(_sortDescending ? "down" : "up")-fill"></i>
+                }
+            </th>
         }
     </tr>
     </thead>
@@ -67,9 +78,18 @@
     
     [Parameter]
     public Dictionary<string, string> Parameters { get; set; }
+
+    [Parameter]
+    public bool ShowSearch { get; set; }
+
+    [Parameter]
+    public string SearchPlaceholder { get; set; } = "Search...";
     
     private PagedReader<TModel> _reader;
     private List<TModel> _pageItems;
+    private string _sortField;
+    private bool _sortDescending;
+    private string _searchTerm = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -114,5 +134,39 @@
         var results = await _reader.PreviousPageAsync();
         _pageItems = results.Items;
         StateHasChanged();
+    }
+
+    private async Task OnSort(ColumnDefinition<TModel> column)
+    {
+        if (string.IsNullOrEmpty(column.SortField))
+            return;
+
+        if (_sortField == column.SortField)
+        {
+            _sortDescending = !_sortDescending;
+        }
+        else
+        {
+            _sortField = column.SortField;
+            _sortDescending = false;
+        }
+
+        Parameters ??= new Dictionary<string, string>();
+        Parameters["sortField"] = _sortField;
+        Parameters["sortDesc"] = _sortDescending.ToString().ToLower();
+
+        await Requery();
+    }
+
+    private async Task OnSearchChanged(ChangeEventArgs e)
+    {
+        _searchTerm = e.Value?.ToString() ?? string.Empty;
+        Parameters ??= new Dictionary<string, string>();
+        if (string.IsNullOrEmpty(_searchTerm))
+            Parameters.Remove("search");
+        else
+            Parameters["search"] = _searchTerm;
+
+        await Requery();
     }
 }

--- a/Valour/Client/Utility/QueryTableDefinitions.cs
+++ b/Valour/Client/Utility/QueryTableDefinitions.cs
@@ -12,5 +12,6 @@ public class RowData<TModel>
 public class ColumnDefinition<TModel>
 {
     public string Name { get; set; }
+    public string SortField { get; set; }
     public RenderFragment<RowData<TModel>> RenderFragment { get; set; }
 }

--- a/Valour/Shared/Models/PlanetBanQueryModel.cs
+++ b/Valour/Shared/Models/PlanetBanQueryModel.cs
@@ -1,0 +1,8 @@
+namespace Valour.Shared.Models;
+
+public class PlanetBanQueryModel : QueryModel
+{
+    public long PlanetId { get; set; }
+
+    public override string GetApiUrl() => $"api/planets/{PlanetId}/bans";
+}

--- a/Valour/Shared/Models/PlanetMemberQueryModel.cs
+++ b/Valour/Shared/Models/PlanetMemberQueryModel.cs
@@ -1,0 +1,8 @@
+namespace Valour.Shared.Models;
+
+public class PlanetMemberQueryModel : QueryModel
+{
+    public long PlanetId { get; set; }
+
+    public override string GetApiUrl() => $"api/planets/{PlanetId}/members";
+}


### PR DESCRIPTION
## Summary
- add QueryModels for planet members and bans
- support filters and sorting in `ModelQueryEngine`
- extend `QueryTable` with sorting and search
- convert planet member and ban modals to use `QueryTable`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*