### PR TITLE
Enhance member/ban queries and table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -378,3 +378,5 @@ _UpgradeReport_Files/
 [Pp]ackages/
 
 **/.idea/.idea**
+dotnet/
+dotnet-install.sh

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor
@@ -38,8 +38,8 @@
             },
             new()
             {
-                Name = "Role",
-                RenderFragment = row => @<span>@row.Row.PrimaryRole?.Name</span>
+                Name = "Roles",
+                RenderFragment = row => @<div class="role-tags">@foreach (var r in row.Row.Roles){<span class="role-pill" style="border-color:@r.Color">@r.Name</span>}</div>
             },
             new()
             {

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetUsersComponent.razor.css
@@ -1,0 +1,11 @@
+.role-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25em;
+}
+.role-pill {
+    padding: 2px 6px;
+    border-radius: 1em;
+    font-size: 12px;
+    border: 1px solid #ccc;
+}

--- a/Valour/Client/Components/Utility/QueryTable.razor
+++ b/Valour/Client/Components/Utility/QueryTable.razor
@@ -1,4 +1,5 @@
 @using Valour.Sdk.Nodes
+@using Valour.Sdk.ModelLogic
 @typeparam TModel where TModel : ClientModel<TModel>
 @inject ValourClient Client
 
@@ -8,7 +9,7 @@
     return;
 }
 
-@if (_pageItems is null)
+@if (!Infinite && _pageItems is null)
 {
     <h6>Loading...</h6>
     return;
@@ -19,8 +20,8 @@
     <input class="form-control mt-2 mb-2" placeholder="@SearchPlaceholder" @onchange="OnSearchChanged" />
 }
 
-<table class="table">
-    <thead>
+<table class="table" style="@(Infinite ? $"height:{Height}px; display:block; overflow-y:auto;" : null)">
+    <thead style="@(Infinite ? "position:sticky;top:0;" : null)">
     <tr>
         @foreach (var column in Columns)
         {
@@ -35,14 +36,28 @@
     </tr>
     </thead>
     <tbody>
-    @foreach (var item in _pageItems)
+    @if (Infinite)
     {
-        <tr>
-            @foreach (var column in Columns)
-            {
-                <td>@column.RenderFragment(new RowData<TModel>(){ Row = item, Table = this })</td>
-            }
-        </tr>
+        <Virtualize @ref="_virtualize" ItemsProvider="ProvideVirtualItems" OverscanCount="20" TItem="TModel">
+            <tr @key="context">
+                @foreach (var column in Columns)
+                {
+                    <td>@column.RenderFragment(new RowData<TModel>() { Row = context, Table = this })</td>
+                }
+            </tr>
+        </Virtualize>
+    }
+    else
+    {
+        @foreach (var item in _pageItems)
+        {
+            <tr>
+                @foreach (var column in Columns)
+                {
+                    <td>@column.RenderFragment(new RowData<TModel>(){ Row = item, Table = this })</td>
+                }
+            </tr>
+        }
     }
     </tbody>
 </table>
@@ -75,9 +90,15 @@
     
     [Parameter]
     public QueryModel Model { get; set; }
-    
+
     [Parameter]
     public Dictionary<string, string> Parameters { get; set; }
+
+    [Parameter]
+    public bool Infinite { get; set; } = false;
+
+    [Parameter]
+    public int Height { get; set; } = 300;
 
     [Parameter]
     public bool ShowSearch { get; set; }
@@ -87,6 +108,8 @@
     
     private PagedModelReader<TModel> _reader;
     private List<TModel> _pageItems;
+    private ModelQueryEngine<TModel> _engine;
+    private Virtualize<TModel> _virtualize;
     private string _sortField;
     private bool _sortDescending;
     private string _searchTerm = string.Empty;
@@ -105,20 +128,39 @@
 
         if (Node is null)
             Node = Client.PrimaryNode;
-        
-        _reader = new PagedModelReader<TModel>(Node, Model.GetApiUrl(), PageSize);
+
+        if (Infinite)
+        {
+            _engine = new ModelQueryEngine<TModel>(Node, Model.GetApiUrl());
+        }
+        else
+        {
+            _reader = new PagedModelReader<TModel>(Node, Model.GetApiUrl(), PageSize);
+        }
 
         await Requery();
     }
 
     public async Task Requery()
     {
-        _reader.SetModel(Model);
-        _reader.SetParameters(Parameters);
-        
-        var response = await _reader.RefreshCurrentPageAsync();
-        _pageItems = response.Items;
-        
+        if (Infinite)
+        {
+            _engine.ClearFilters();
+            if (!string.IsNullOrEmpty(_searchTerm))
+                _engine.SetFilter("search", _searchTerm);
+            if (!string.IsNullOrEmpty(_sortField))
+                _engine.SetSort(_sortField, _sortDescending);
+            await _virtualize?.RefreshDataAsync();
+        }
+        else
+        {
+            _reader.SetModel(Model);
+            _reader.SetParameters(Parameters);
+
+            var response = await _reader.RefreshCurrentPageAsync();
+            _pageItems = response.Items;
+        }
+
         StateHasChanged();
     }
 
@@ -168,5 +210,10 @@
             Parameters["search"] = _searchTerm;
 
         await Requery();
+    }
+
+    private async ValueTask<ItemsProviderResult<TModel>> ProvideVirtualItems(ItemsProviderRequest request)
+    {
+        return await _engine.GetVirtualizedItemsAsync(request);
     }
 }

--- a/Valour/Server/Api/Dynamic/PlanetApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetApi.cs
@@ -201,7 +201,10 @@ public class PlanetApi
         long id,
         PlanetMemberService memberService,
         int skip = 0,
-        int take = 50)
+        int take = 50,
+        string sortField = null,
+        bool sortDesc = false,
+        string search = null)
     {
         var member = await memberService.GetCurrentAsync(id);
         if (member is null)
@@ -210,7 +213,14 @@ public class PlanetApi
         if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
             return ValourResult.LacksPermission(PlanetPermissions.Manage);
 
-        var members = await memberService.QueryPlanetMembersAsync(id, skip, take);
+        if (queryModel is not null)
+        {
+            sortField = queryModel.Sort?.Field ?? sortField;
+            sortDesc = queryModel.Sort?.Descending ?? sortDesc;
+            search = queryModel.Filter?.Search ?? search;
+        }
+
+        var members = await memberService.QueryPlanetMembersAsync(id, skip, take, search, sortField, sortDesc);
 
         return Results.Json(members);
     }
@@ -356,14 +366,19 @@ public class PlanetApi
         return Results.Json(inviteIds);
     }
 
+    [ValourRoute(HttpVerbs.Post, "api/planets/{id}/bans")]
     [ValourRoute(HttpVerbs.Get, "api/planets/{id}/bans")]
     [UserRequired(UserPermissionsEnum.PlanetManagement)]
     public static async Task<IResult> GetBansRouteAsync(
+        [FromBody] PlanetBanQueryModel? queryModel,
         long id,
         PlanetMemberService memberService,
         PlanetBanService banService,
         int skip = 0,
-        int take = 50)
+        int take = 50,
+        string sortField = null,
+        bool sortDesc = false,
+        string search = null)
     {
         var member = await memberService.GetCurrentAsync(id);
         if (member is null)
@@ -372,7 +387,14 @@ public class PlanetApi
         if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
             return ValourResult.LacksPermission(PlanetPermissions.Manage);
 
-        var bans = await banService.QueryPlanetBansAsync(id, skip, take);
+        if (queryModel is not null)
+        {
+            sortField = queryModel.Sort?.Field ?? sortField;
+            sortDesc = queryModel.Sort?.Descending ?? sortDesc;
+            search = queryModel.Filter?.Search ?? search;
+        }
+
+        var bans = await banService.QueryPlanetBansAsync(id, skip, take, search, sortField, sortDesc);
 
         return Results.Json(bans);
     }

--- a/Valour/Shared/Models/PlanetBanQueryModel.cs
+++ b/Valour/Shared/Models/PlanetBanQueryModel.cs
@@ -3,6 +3,8 @@ namespace Valour.Shared.Models;
 public class PlanetBanQueryModel : QueryModel
 {
     public long PlanetId { get; set; }
+    public QueryFilter Filter { get; set; }
+    public QuerySort Sort { get; set; }
 
     public override string GetApiUrl() => $"api/planets/{PlanetId}/bans";
 }

--- a/Valour/Shared/Models/PlanetMemberQueryModel.cs
+++ b/Valour/Shared/Models/PlanetMemberQueryModel.cs
@@ -3,6 +3,8 @@ namespace Valour.Shared.Models;
 public class PlanetMemberQueryModel : QueryModel
 {
     public long PlanetId { get; set; }
+    public QueryFilter Filter { get; set; }
+    public QuerySort Sort { get; set; }
 
     public override string GetApiUrl() => $"api/planets/{PlanetId}/members";
 }

--- a/Valour/Shared/Models/QueryFilter.cs
+++ b/Valour/Shared/Models/QueryFilter.cs
@@ -1,0 +1,6 @@
+namespace Valour.Shared.Models;
+
+public class QueryFilter
+{
+    public string Search { get; set; }
+}

--- a/Valour/Shared/Models/QuerySort.cs
+++ b/Valour/Shared/Models/QuerySort.cs
@@ -1,0 +1,7 @@
+namespace Valour.Shared.Models;
+
+public class QuerySort
+{
+    public string Field { get; set; }
+    public bool Descending { get; set; }
+}


### PR DESCRIPTION
## Summary
- support generic query filters and sorts for members and bans
- extend planet APIs with sorting and searching
- add infinite scrolling option for `QueryTable`
- display member roles as colored pills
- ignore tooling leftovers

## Testing
- `dotnet test` *(fails: `dotnet` not found)*