### PR TITLE
Add planet automod features

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetComponent.razor
@@ -31,6 +31,7 @@
     private RenderFragment MembersContent => @<EditPlanetUsersComponent Planet="@Data.Planet" />;
     private RenderFragment BansContent => @<EditPlanetBansComponent Planet="@Data.Planet" />;
     private RenderFragment RolesContent => @<EditPlanetRolesComponent Planet="@Data.Planet" />;
+    private RenderFragment ModerationContent => @<EditPlanetModerationComponent Planet="@Data.Planet" />;
     private RenderFragment EconomyContent => @<EditPlanetEconomyComponent Planet="@Data.Planet" />;
     private RenderFragment DeleteContent => @<div></div>;
 
@@ -91,6 +92,13 @@
                         Icon = "person-fill",
                         Description = "Manage roles and permissions",
                         Content = RolesContent
+                    },
+                    new MainMenu.MenuItem()
+                    {
+                        Name = "Moderation",
+                        Icon = "shield-lock-fill",
+                        Description = "Automated moderation settings",
+                        Content = ModerationContent
                     },
                     new MainMenu.MenuItem()
                     {

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetModerationComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetModerationComponent.razor
@@ -1,0 +1,43 @@
+@using Valour.Sdk.Models
+@using Valour.Shared.Models.Staff
+@inject ValourClient Client
+
+<h3>Moderation <i class="bi bi-shield-lock-fill"></i></h3>
+<p class="subtitle">AUTOMOD TRIGGERS</p>
+
+<div class="form-group mt-2">
+    <label>Name</label>
+    <input class="form-control" @bind="_newTrigger.Name" />
+</div>
+<div class="form-group mt-2">
+    <label>Trigger Words (comma separated)</label>
+    <input class="form-control" @bind="_newTrigger.TriggerWords" />
+</div>
+<div class="form-group mt-2">
+    <label>Type</label>
+    <select class="form-control" @bind="_newTrigger.Type">
+        @foreach (AutomodTriggerType t in Enum.GetValues<AutomodTriggerType>())
+        {
+            <option value="@t">@t</option>
+        }
+    </select>
+</div>
+<button class="v-btn secondary" @onclick="CreateTrigger">Create Trigger</button>
+<ResultLabel Result="@_result" />
+
+@code {
+    [Parameter]
+    public Planet Planet { get; set; }
+
+    private AutomodTrigger _newTrigger = new();
+    private ITaskResult _result;
+
+    private async Task CreateTrigger()
+    {
+        _newTrigger.PlanetId = Planet.Id;
+        var res = await Client.AutomodService.CreateTriggerAsync(_newTrigger);
+        _result = res;
+        if (res.Success)
+            _newTrigger = new AutomodTrigger();
+    }
+}

--- a/Valour/Database/AutomodAction.cs
+++ b/Valour/Database/AutomodAction.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using Valour.Shared.Models.Staff;
+using Valour.Shared.Models;
+
+namespace Valour.Database;
+
+public class AutomodAction : ISharedAutomodAction
+{
+    public Guid Id { get; set; }
+    public Guid? PriorAction { get; set; }
+    public Guid TriggerId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodActionType ActionType { get; set; }
+    public long PlanetId { get; set; }
+    public long TargetMemberId { get; set; }
+    public long? MessageId { get; set; }
+    public long? RoleId { get; set; }
+    public DateTime? Expires { get; set; }
+    public string Reason { get; set; }
+    public string Message { get; set; }
+
+    public static void SetupDbModel(ModelBuilder builder)
+    {
+        builder.Entity<AutomodAction>(e =>
+        {
+            e.ToTable("automod_actions");
+            e.HasKey(x => x.Id);
+            e.Property(x => x.Id).HasColumnName("id");
+            e.Property(x => x.PriorAction).HasColumnName("prior_action");
+            e.Property(x => x.TriggerId).HasColumnName("trigger_id");
+            e.Property(x => x.MemberAddedBy).HasColumnName("member_added_by");
+            e.Property(x => x.ActionType).HasColumnName("action_type");
+            e.Property(x => x.PlanetId).HasColumnName("planet_id");
+            e.Property(x => x.TargetMemberId).HasColumnName("target_member_id");
+            e.Property(x => x.MessageId).HasColumnName("message_id");
+            e.Property(x => x.RoleId).HasColumnName("role_id");
+            e.Property(x => x.Expires).HasColumnName("expires");
+            e.Property(x => x.Reason).HasColumnName("reason");
+            e.Property(x => x.Message).HasColumnName("message");
+            e.HasIndex(x => x.TriggerId);
+            e.HasIndex(x => x.PlanetId);
+        });
+    }
+}

--- a/Valour/Database/AutomodTrigger.cs
+++ b/Valour/Database/AutomodTrigger.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Valour.Shared.Models.Staff;
+using Valour.Shared.Models;
+
+namespace Valour.Database;
+
+public class AutomodTrigger : ISharedAutomodTrigger, ISharedPlanetModel<Guid>
+{
+    ///////////////////////
+    // Entity Properties //
+    ///////////////////////
+
+    public Guid Id { get; set; }
+    public long PlanetId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodTriggerType Type { get; set; }
+    public string Name { get; set; }
+    public string? TriggerWords { get; set; }
+
+    public static void SetupDbModel(ModelBuilder builder)
+    {
+        builder.Entity<AutomodTrigger>(e =>
+        {
+            e.ToTable("automod_triggers");
+            e.HasKey(x => x.Id);
+            e.Property(x => x.Id).HasColumnName("id");
+            e.Property(x => x.PlanetId).HasColumnName("planet_id");
+            e.Property(x => x.MemberAddedBy).HasColumnName("member_added_by");
+            e.Property(x => x.Type).HasColumnName("type");
+            e.Property(x => x.Name).HasColumnName("name");
+            e.Property(x => x.TriggerWords).HasColumnName("trigger_words");
+            e.HasIndex(x => x.PlanetId);
+        });
+    }
+}

--- a/Valour/Database/Context/ValourDB.cs
+++ b/Valour/Database/Context/ValourDB.cs
@@ -142,6 +142,16 @@ public partial class ValourDb : DbContext
     public DbSet<PlanetInvite> PlanetInvites { get; set; }
 
     /// <summary>
+    /// Table for automod triggers
+    /// </summary>
+    public DbSet<AutomodTrigger> AutomodTriggers { get; set; }
+
+    /// <summary>
+    /// Table for automod actions
+    /// </summary>
+    public DbSet<AutomodAction> AutomodActions { get; set; }
+
+    /// <summary>
     /// Table for planet invites
     /// </summary>
     public DbSet<StatObject> Stats { get; set; }
@@ -266,7 +276,10 @@ public partial class ValourDb : DbContext
         Referral.SetupDbModel(modelBuilder);
         UserCryptoWallet.SetupDbModel(modelBuilder);
         UserCryptoNonce.SetupDbModel(modelBuilder);
-      
+
+        AutomodTrigger.SetupDbModel(modelBuilder);
+        AutomodAction.SetupDbModel(modelBuilder);
+
         Valour.Database.NodeStats.SetupDbModel(modelBuilder);
         
         OldPlanetRoleMember.SetupDbModel(modelBuilder);

--- a/Valour/Sdk/Client/ValourClient.cs
+++ b/Valour/Sdk/Client/ValourClient.cs
@@ -43,6 +43,7 @@ public class ValourClient
     public readonly TenorService TenorService;
     public readonly SubscriptionService SubscriptionService;
     public readonly NotificationService NotificationService;
+    public readonly AutomodService AutomodService;
     public readonly EcoService EcoService;
     public readonly StaffService StaffService;
     public readonly OauthService OauthService;
@@ -115,6 +116,7 @@ public class ValourClient
         BotService = new BotService(this);
         SubscriptionService = new SubscriptionService(this);
         NotificationService = new NotificationService(this);
+        AutomodService = new AutomodService(this);
         EcoService = new EcoService(this);
         StaffService = new StaffService(this);
         OauthService = new OauthService(this);

--- a/Valour/Sdk/Models/AutomodAction.cs
+++ b/Valour/Sdk/Models/AutomodAction.cs
@@ -1,0 +1,36 @@
+using Valour.Sdk.Client;
+using Valour.Sdk.ModelLogic;
+using Valour.Shared.Models.Staff;
+
+namespace Valour.Sdk.Models;
+
+public class AutomodAction : ClientPlanetModel<AutomodAction, Guid>, ISharedAutomodAction
+{
+    public override string BaseRoute => $"api/planets/{PlanetId}/automod/triggers/{TriggerId}/actions";
+    public override string IdRoute => $"{BaseRoute}/{Id}";
+
+    public Guid? PriorAction { get; set; }
+    public Guid TriggerId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodActionType ActionType { get; set; }
+    public long PlanetId { get; set; }
+    public long TargetMemberId { get; set; }
+    public long? MessageId { get; set; }
+    public long? RoleId { get; set; }
+    public DateTime? Expires { get; set; }
+    public string Reason { get; set; }
+    public string Message { get; set; }
+
+    [JsonConstructor]
+    private AutomodAction() : base() { }
+    public AutomodAction(ValourClient client) : base(client) { }
+
+    protected override long? GetPlanetId() => PlanetId;
+
+    public override AutomodAction AddToCache(ModelInsertFlags flags = ModelInsertFlags.None)
+    {
+        return this;
+    }
+
+    public override AutomodAction RemoveFromCache(bool skipEvents = false) => this;
+}

--- a/Valour/Sdk/Models/AutomodTrigger.cs
+++ b/Valour/Sdk/Models/AutomodTrigger.cs
@@ -1,0 +1,31 @@
+using Valour.Sdk.Client;
+using Valour.Sdk.ModelLogic;
+using Valour.Shared.Models.Staff;
+using Valour.Shared.Models;
+
+namespace Valour.Sdk.Models;
+
+public class AutomodTrigger : ClientPlanetModel<AutomodTrigger, Guid>, ISharedAutomodTrigger, ISharedPlanetModel
+{
+    public override string BaseRoute => $"api/planets/{PlanetId}/automod/triggers";
+    public override string IdRoute => $"{BaseRoute}/{Id}";
+
+    public long PlanetId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodTriggerType Type { get; set; }
+    public string Name { get; set; }
+    public string? TriggerWords { get; set; }
+
+    [JsonConstructor]
+    private AutomodTrigger() : base() { }
+    public AutomodTrigger(ValourClient client) : base(client) { }
+
+    protected override long? GetPlanetId() => PlanetId;
+
+    public override AutomodTrigger AddToCache(ModelInsertFlags flags = ModelInsertFlags.None)
+    {
+        return this;
+    }
+
+    public override AutomodTrigger RemoveFromCache(bool skipEvents = false) => this;
+}

--- a/Valour/Sdk/Services/AutomodService.cs
+++ b/Valour/Sdk/Services/AutomodService.cs
@@ -1,0 +1,30 @@
+using Valour.Sdk.Client;
+using Valour.Sdk.ModelLogic;
+
+namespace Valour.Sdk.Services;
+
+public class AutomodService : ServiceBase
+{
+    private readonly ValourClient _client;
+
+    public AutomodService(ValourClient client)
+    {
+        _client = client;
+        SetupLogging(client.Logger, new("Automod", "#009900"));
+    }
+
+    public async Task<TaskResult<AutomodTrigger>> CreateTriggerAsync(AutomodTrigger trigger)
+    {
+        var planet = await _client.PlanetService.FetchPlanetAsync(trigger.PlanetId);
+        return await planet.Node.PostJsonAsync(trigger.BaseRoute, trigger);
+    }
+
+    public async Task<TaskResult<AutomodAction>> CreateActionAsync(AutomodAction action)
+    {
+        var planet = await _client.PlanetService.FetchPlanetAsync(action.PlanetId);
+        return await planet.Node.PostJsonAsync(action.BaseRoute, action);
+    }
+
+    public ModelQueryEngine<AutomodTrigger> GetTriggerQueryEngine(Planet planet) =>
+        new ModelQueryEngine<AutomodTrigger>(planet.Node, $"api/planets/{planet.Id}/automod/triggers/query");
+}

--- a/Valour/Server/Api/Dynamic/AutomodApi.cs
+++ b/Valour/Server/Api/Dynamic/AutomodApi.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Mvc;
+using Valour.Shared.Authorization;
+using Valour.Shared.Models.Staff;
+using Valour.Server.Models;
+using Valour.Server.Services;
+
+namespace Valour.Server.Api.Dynamic;
+
+public class AutomodApi
+{
+    [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> PostTriggerAsync(
+        long planetId,
+        [FromBody] AutomodTrigger trigger,
+        PlanetMemberService memberService,
+        AutomodService automodService)
+    {
+        if (trigger is null)
+            return ValourResult.BadRequest("Include trigger in body.");
+
+        var member = await memberService.GetCurrentAsync(planetId);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        trigger.PlanetId = planetId;
+        trigger.MemberAddedBy = member.Id;
+        var result = await automodService.CreateTriggerAsync(trigger);
+        if (!result.Success)
+            return ValourResult.Problem(result.Message);
+
+        return Results.Created($"api/automod/triggers/{result.Data.Id}", result.Data);
+    }
+
+    [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers/{triggerId}/actions")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> PostActionAsync(
+        long planetId,
+        Guid triggerId,
+        [FromBody] AutomodAction action,
+        PlanetMemberService memberService,
+        AutomodService automodService)
+    {
+        if (action is null)
+            return ValourResult.BadRequest("Include action in body.");
+
+        var member = await memberService.GetCurrentAsync(planetId);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        action.TriggerId = triggerId;
+        action.PlanetId = planetId;
+        action.MemberAddedBy = member.Id;
+
+        var result = await automodService.CreateActionAsync(action);
+        if (!result.Success)
+            return ValourResult.Problem(result.Message);
+
+        return Results.Created($"api/automod/actions/{result.Data.Id}", result.Data);
+    }
+}

--- a/Valour/Server/Api/Dynamic/PlanetApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetApi.cs
@@ -5,6 +5,8 @@ using Valour.Server.Database;
 using Valour.Shared.Authorization;
 using Valour.Shared.Models;
 using Valour.Shared.Queries;
+using Valour.Server.Models;
+using Valour.Server.Services;
 
 namespace Valour.Server.Api.Dynamic;
 
@@ -380,6 +382,28 @@ public class PlanetApi
         var bans = await banService.QueryPlanetBansAsync(planetId, queryRequest);
 
         return Results.Json(bans);
+    }
+
+    [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers/query")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> QueryAutomodTriggersAsync(
+        [FromBody] QueryRequest? queryRequest,
+        long planetId,
+        PlanetMemberService memberService,
+        AutomodService automodService)
+    {
+        if (queryRequest is null)
+            return ValourResult.BadRequest("Include query in body.");
+
+        var member = await memberService.GetCurrentAsync(planetId);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        var result = await automodService.QueryPlanetTriggersAsync(planetId, queryRequest);
+        return Results.Json(result);
     }
 
     [ValourRoute(HttpVerbs.Get, "api/planets/discoverable")]

--- a/Valour/Server/Mapping/AutomodActionMapper.cs
+++ b/Valour/Server/Mapping/AutomodActionMapper.cs
@@ -1,0 +1,46 @@
+namespace Valour.Server.Mapping;
+
+public static class AutomodActionMapper
+{
+    public static AutomodAction ToModel(this Valour.Database.AutomodAction action)
+    {
+        if (action is null)
+            return null;
+        return new AutomodAction
+        {
+            Id = action.Id,
+            PriorAction = action.PriorAction,
+            TriggerId = action.TriggerId,
+            MemberAddedBy = action.MemberAddedBy,
+            ActionType = action.ActionType,
+            PlanetId = action.PlanetId,
+            TargetMemberId = action.TargetMemberId,
+            MessageId = action.MessageId,
+            RoleId = action.RoleId,
+            Expires = action.Expires,
+            Reason = action.Reason,
+            Message = action.Message
+        };
+    }
+
+    public static Valour.Database.AutomodAction ToDatabase(this AutomodAction action)
+    {
+        if (action is null)
+            return null;
+        return new Valour.Database.AutomodAction
+        {
+            Id = action.Id,
+            PriorAction = action.PriorAction,
+            TriggerId = action.TriggerId,
+            MemberAddedBy = action.MemberAddedBy,
+            ActionType = action.ActionType,
+            PlanetId = action.PlanetId,
+            TargetMemberId = action.TargetMemberId,
+            MessageId = action.MessageId,
+            RoleId = action.RoleId,
+            Expires = action.Expires,
+            Reason = action.Reason,
+            Message = action.Message
+        };
+    }
+}

--- a/Valour/Server/Mapping/AutomodTriggerMapper.cs
+++ b/Valour/Server/Mapping/AutomodTriggerMapper.cs
@@ -1,0 +1,34 @@
+namespace Valour.Server.Mapping;
+
+public static class AutomodTriggerMapper
+{
+    public static AutomodTrigger ToModel(this Valour.Database.AutomodTrigger trigger)
+    {
+        if (trigger is null)
+            return null;
+        return new AutomodTrigger
+        {
+            Id = trigger.Id,
+            PlanetId = trigger.PlanetId,
+            MemberAddedBy = trigger.MemberAddedBy,
+            Type = trigger.Type,
+            Name = trigger.Name,
+            TriggerWords = trigger.TriggerWords
+        };
+    }
+
+    public static Valour.Database.AutomodTrigger ToDatabase(this AutomodTrigger trigger)
+    {
+        if (trigger is null)
+            return null;
+        return new Valour.Database.AutomodTrigger
+        {
+            Id = trigger.Id,
+            PlanetId = trigger.PlanetId,
+            MemberAddedBy = trigger.MemberAddedBy,
+            Type = trigger.Type,
+            Name = trigger.Name,
+            TriggerWords = trigger.TriggerWords
+        };
+    }
+}

--- a/Valour/Server/Models/AutomodAction.cs
+++ b/Valour/Server/Models/AutomodAction.cs
@@ -1,0 +1,19 @@
+using Valour.Shared.Models.Staff;
+using Valour.Shared.Models;
+
+namespace Valour.Server.Models;
+
+public class AutomodAction : ServerModel<Guid>, ISharedAutomodAction
+{
+    public Guid? PriorAction { get; set; }
+    public Guid TriggerId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodActionType ActionType { get; set; }
+    public long PlanetId { get; set; }
+    public long TargetMemberId { get; set; }
+    public long? MessageId { get; set; }
+    public long? RoleId { get; set; }
+    public DateTime? Expires { get; set; }
+    public string Reason { get; set; }
+    public string Message { get; set; }
+}

--- a/Valour/Server/Models/AutomodTrigger.cs
+++ b/Valour/Server/Models/AutomodTrigger.cs
@@ -1,0 +1,13 @@
+using Valour.Shared.Models.Staff;
+using Valour.Shared.Models;
+
+namespace Valour.Server.Models;
+
+public class AutomodTrigger : ServerModel<Guid>, ISharedAutomodTrigger, ISharedPlanetModel
+{
+    public long PlanetId { get; set; }
+    public long MemberAddedBy { get; set; }
+    public AutomodTriggerType Type { get; set; }
+    public string Name { get; set; }
+    public string? TriggerWords { get; set; }
+}

--- a/Valour/Server/Program.cs
+++ b/Valour/Server/Program.cs
@@ -343,6 +343,7 @@ public partial class Program
         services.AddScoped<PlanetRoleService>();
         services.AddScoped<PlanetService>();
         services.AddScoped<TenorFavoriteService>();
+        services.AddScoped<AutomodService>();
         services.AddScoped<TokenService>();
         services.AddScoped<UserFriendService>();
         services.AddScoped<UserOnlineService>();

--- a/Valour/Server/Services/AutomodService.cs
+++ b/Valour/Server/Services/AutomodService.cs
@@ -1,0 +1,102 @@
+using Valour.Server.Database;
+using Valour.Shared;
+using Valour.Shared.Queries;
+using Valour.Server.Mapping;
+using Valour.Server.Models;
+
+namespace Valour.Server.Services;
+
+public class AutomodService
+{
+    private readonly ValourDb _db;
+    private readonly ILogger<AutomodService> _logger;
+    private readonly CoreHubService _coreHub;
+
+    public AutomodService(
+        ValourDb db,
+        ILogger<AutomodService> logger,
+        CoreHubService coreHub)
+    {
+        _db = db;
+        _logger = logger;
+        _coreHub = coreHub;
+    }
+
+    public async Task<AutomodTrigger?> GetTriggerAsync(Guid id) =>
+        (await _db.AutomodTriggers.FindAsync(id))?.ToModel();
+
+    public async Task<List<AutomodTrigger>> GetPlanetTriggersAsync(long planetId) =>
+        await _db.AutomodTriggers.Where(x => x.PlanetId == planetId)
+            .Select(x => x.ToModel()).ToListAsync();
+
+    public async Task<QueryResponse<AutomodTrigger>> QueryPlanetTriggersAsync(long planetId, QueryRequest request)
+    {
+        var take = Math.Min(50, request.Take);
+        var skip = request.Skip;
+        var query = _db.AutomodTriggers.Where(x => x.PlanetId == planetId).AsQueryable();
+        var total = await query.CountAsync();
+        var items = await query.Skip(skip).Take(take).Select(x => x.ToModel()).ToListAsync();
+        return new QueryResponse<AutomodTrigger>
+        {
+            Items = items,
+            TotalCount = total
+        };
+    }
+
+    public async Task<TaskResult<AutomodTrigger>> CreateTriggerAsync(AutomodTrigger trigger)
+    {
+        trigger.Id = Guid.NewGuid();
+        try
+        {
+            await _db.AutomodTriggers.AddAsync(trigger.ToDatabase());
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message);
+            return new(false, e.Message);
+        }
+
+        _coreHub.NotifyPlanetItemChange(trigger);
+        return new(true, "Success", trigger);
+    }
+
+    public async Task<TaskResult> DeleteTriggerAsync(AutomodTrigger trigger)
+    {
+        try
+        {
+            var dbItem = await _db.AutomodTriggers.FindAsync(trigger.Id);
+            if (dbItem != null)
+            {
+                _db.AutomodTriggers.Remove(dbItem);
+                await _db.SaveChangesAsync();
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message);
+            return new(false, e.Message);
+        }
+
+        _coreHub.NotifyPlanetItemDelete(trigger);
+        return new(true, "Success");
+    }
+
+    public async Task<TaskResult<AutomodAction>> CreateActionAsync(AutomodAction action)
+    {
+        action.Id = Guid.NewGuid();
+        try
+        {
+            await _db.AutomodActions.AddAsync(action.ToDatabase());
+            await _db.SaveChangesAsync();
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message);
+            return new(false, e.Message);
+        }
+
+        _coreHub.NotifyPlanetItemChange(action.PlanetId, action);
+        return new(true, "Success", action);
+    }
+}


### PR DESCRIPTION
## Summary
- add AutomodTrigger and AutomodAction database models
- setup EF mappings and DbSets
- add server models, mapping helpers, and AutomodService with API endpoints
- add client models and AutomodService
- introduce Moderation page in planet settings for creating triggers
- register new service and menu item

## Testing
- `./dotnet/dotnet build Valour.sln -c Release` *(fails: NU1301 failed to retrieve packages)*
- `./dotnet/dotnet test Valour.sln -c Release` *(fails: NU1301 failed to retrieve packages)*