### PR TITLE
Implement automod triggers and bypass permission

### DIFF
--- a/Valour/Server/Services/PlanetMemberService.cs
+++ b/Valour/Server/Services/PlanetMemberService.cs
@@ -15,6 +15,7 @@ public class PlanetMemberService
     private readonly TokenService _tokenService;
     private readonly PlanetPermissionService _permissionService;
     private readonly HostedPlanetService _hostedPlanetService;
+    private readonly AutomodService _automodService;
     private readonly ILogger<PlanetMemberService> _logger;
     
     private static readonly ConcurrentDictionary<(long, long), long> MemberIdLookup = new();
@@ -29,9 +30,10 @@ public class PlanetMemberService
         ValourDb db,
         CoreHubService coreHub,
         TokenService tokenService,
-        ILogger<PlanetMemberService> logger, 
-        PlanetPermissionService permissionService, 
-        HostedPlanetService hostedPlanetService)
+        ILogger<PlanetMemberService> logger,
+        PlanetPermissionService permissionService,
+        HostedPlanetService hostedPlanetService,
+        AutomodService automodService)
     {
         _db = db;
         _coreHub = coreHub;
@@ -39,6 +41,7 @@ public class PlanetMemberService
         _logger = logger;
         _permissionService = permissionService;
         _hostedPlanetService = hostedPlanetService;
+        _automodService = automodService;
     }
 
     /// <summary>
@@ -375,6 +378,8 @@ public class PlanetMemberService
         var model = member.ToModel();
 
         _coreHub.NotifyPlanetItemChange(model);
+
+        await _automodService.HandleMemberJoinAsync(model);
 
         Console.WriteLine($"User {user.Name} ({user.Id}) has joined {planet.Name} ({planet.Id})");
 

--- a/Valour/Server/Services/PlanetPermissionService.cs
+++ b/Valour/Server/Services/PlanetPermissionService.cs
@@ -104,6 +104,18 @@ public class PlanetPermissionService
         return Permission.HasPermission(perms, permission);
     }
 
+    public async ValueTask<bool> HasPlanetPermissionAsync(ISharedPlanetMember member, PlanetPermission permission)
+    {
+        if (member is null)
+            return false;
+
+        if (permission.Value == PlanetPermissions.View.Value)
+            return true;
+
+        var perms = await GetPlanetPermissionsAsync(member);
+        return Permission.HasPermission(perms, permission);
+    }
+
     /// <summary>
     /// When a channel’s inheritance settings change, clear its caches.
     /// </summary>

--- a/Valour/Shared/Authorization/Permissions.cs
+++ b/Valour/Shared/Authorization/Permissions.cs
@@ -502,6 +502,7 @@ public enum PlanetPermissionsEnum
     ManageCurrency,
     ManageEcoAccounts,
     ForceTransactions,
+    BypassAutomod,
 }
 
 /// <summary>
@@ -537,8 +538,9 @@ public static class PlanetPermissions
                 ManageCurrency,
                 ManageEcoAccounts,
                 ForceTransactions,
-                
+
                 MentionAll,
+                BypassAutomod,
         };
     }
 
@@ -561,6 +563,7 @@ public static class PlanetPermissions
     public static readonly PlanetPermission ForceTransactions = new PlanetPermission(0x800, "Force Transactions", "Allow members to force transactions in the planet.");
 
     public static readonly PlanetPermission MentionAll = new PlanetPermission(0x1000, "Mention All", "Allow members to mention all roles.");
+    public static readonly PlanetPermission BypassAutomod = new PlanetPermission(0x2000, "Bypass Automod", "Ignore automod triggers for members with this role.");
 }
 
 public enum PermissionState


### PR DESCRIPTION
## Summary
- add `Bypass Automod` planet permission
- expose permission helper on `PlanetPermissionService`
- implement trigger scanning and action execution in `AutomodService`
- run automod when messages are posted and members join

## Testing
- `./dotnet/dotnet build --no-restore` *(fails: project assets missing)*