### PR TITLE
Add automod trigger management UI

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetModerationComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetModerationComponent.razor
@@ -1,43 +1,97 @@
 @using Valour.Sdk.Models
 @using Valour.Shared.Models.Staff
+@using Valour.Sdk.ModelLogic
 @inject ValourClient Client
 
 <h3>Moderation <i class="bi bi-shield-lock-fill"></i></h3>
 <p class="subtitle">AUTOMOD TRIGGERS</p>
 
-<div class="form-group mt-2">
-    <label>Name</label>
-    <input class="form-control" @bind="_newTrigger.Name" />
-</div>
-<div class="form-group mt-2">
-    <label>Trigger Words (comma separated)</label>
-    <input class="form-control" @bind="_newTrigger.TriggerWords" />
-</div>
-<div class="form-group mt-2">
-    <label>Type</label>
-    <select class="form-control" @bind="_newTrigger.Type">
-        @foreach (AutomodTriggerType t in Enum.GetValues<AutomodTriggerType>())
-        {
-            <option value="@t">@t</option>
-        }
-    </select>
-</div>
-<button class="v-btn secondary" @onclick="CreateTrigger">Create Trigger</button>
+<QueryTable
+    @ref="_table"
+    Columns="@_columns"
+    Engine="@_engine"
+    ShowSearch="true"
+    Infinite="true"
+    SearchPlaceholder="Search name..." />
+
+<button class="v-btn mt-2" @onclick="OpenCreateModal">Add Trigger</button>
 <ResultLabel Result="@_result" />
 
 @code {
     [Parameter]
     public Planet Planet { get; set; }
 
-    private AutomodTrigger _newTrigger = new();
+    [CascadingParameter]
+    public ModalRoot ModalRoot { get; set; }
+
+    private QueryTable<AutomodTrigger> _table;
+    private List<ColumnDefinition<AutomodTrigger>> _columns;
+    private ModelQueryEngine<AutomodTrigger> _engine;
     private ITaskResult _result;
 
-    private async Task CreateTrigger()
+    protected override void OnInitialized()
     {
-        _newTrigger.PlanetId = Planet.Id;
-        var res = await Client.AutomodService.CreateTriggerAsync(_newTrigger);
-        _result = res;
-        if (res.Success)
-            _newTrigger = new AutomodTrigger();
+        Planet ??= WindowService.FocusedPlanet;
+        _engine = Client.AutomodService.GetTriggerQueryEngine(Planet);
+
+        _columns = new()
+        {
+            new()
+            {
+                Name = "Name",
+                SortField = "name",
+                Sortable = true,
+                RenderFragment = row => @<span>@row.Row.Name</span>
+            },
+            new()
+            {
+                Name = "Type",
+                SortField = "type",
+                Sortable = true,
+                RenderFragment = row => @<span>@row.Row.Type</span>
+            },
+            new()
+            {
+                Name = "Words",
+                RenderFragment = row => @<span>@row.Row.TriggerWords</span>
+            },
+            new()
+            {
+                Name = "Actions",
+                RenderFragment = row => @<div class="button-row">
+                        <button class="v-btn secondary" @onclick="(() => ViewTrigger(row.Row))">View</button>
+                        <button class="v-btn danger" @onclick="(() => DeleteTrigger(row.Row))">Remove</button>
+                    </div>,
+                Width = "150px",
+                TextAlign = "right"
+            }
+        };
+    }
+
+    private void OpenCreateModal()
+    {
+        var data = new AutomodTriggerModal.ModalParams
+        {
+            Planet = Planet,
+            Trigger = null
+        };
+        ModalRoot.OpenModal<Moderation.AutomodTriggerModal>(data);
+    }
+
+    private void ViewTrigger(AutomodTrigger trigger)
+    {
+        var data = new AutomodTriggerModal.ModalParams
+        {
+            Planet = Planet,
+            Trigger = trigger
+        };
+        ModalRoot.OpenModal<Moderation.AutomodTriggerModal>(data);
+    }
+
+    private async Task DeleteTrigger(AutomodTrigger trigger)
+    {
+        _result = await trigger.DeleteAsync();
+        if (_result.Success && _table is not null)
+            await _table.Requery();
     }
 }

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
@@ -1,0 +1,127 @@
+@inherits Modal<AutomodTriggerModal.ModalParams>
+@using Valour.Sdk.Models
+@using Valour.Shared.Models.Staff
+@inject ValourClient Client
+
+<BasicModalLayout Title="@(_isNew ? "Add Trigger" : "Edit Trigger")" Icon="shield-lock-fill" MaxWidth="600px">
+    <MainArea>
+        <div class="form-group mt-2">
+            <label>Name</label>
+            <input class="form-control" @bind="_trigger.Name" />
+        </div>
+        <div class="form-group mt-2">
+            <label>Trigger Words (comma separated)</label>
+            <input class="form-control" @bind="_trigger.TriggerWords" />
+        </div>
+        <div class="form-group mt-2">
+            <label>Type</label>
+            <select class="form-control" @bind="_trigger.Type">
+                @foreach (AutomodTriggerType t in Enum.GetValues<AutomodTriggerType>())
+                {
+                    <option value="@t">@t</option>
+                }
+            </select>
+        </div>
+
+        <p class="subtitle mt-3">ACTIONS</p>
+        <QueryTable
+            @ref="_actionTable"
+            Columns="@_actionColumns"
+            Engine="@_actionEngine"
+            Infinite="true"
+            Height="200px"
+            RowHeight="40" />
+
+        <button class="v-btn mt-2" @onclick="OnAddAction">Add Action</button>
+        <ResultLabel Result="@_result" />
+    </MainArea>
+    <ButtonArea>
+        <div class="basic-modal-buttons">
+            <button class="v-btn" @onclick="Close">Cancel</button>
+            <button class="v-btn primary" @onclick="OnSave">Save</button>
+        </div>
+    </ButtonArea>
+</BasicModalLayout>
+
+@code {
+    public class ModalParams
+    {
+        public Planet Planet { get; set; }
+        public AutomodTrigger? Trigger { get; set; }
+    }
+
+    private AutomodTrigger _trigger;
+    private bool _isNew;
+    private ITaskResult _result;
+
+    private QueryTable<AutomodAction> _actionTable;
+    private List<ColumnDefinition<AutomodAction>> _actionColumns;
+    private ModelQueryEngine<AutomodAction> _actionEngine;
+
+    protected override void OnInitialized()
+    {
+        _isNew = Data.Trigger is null;
+        if (Data.Trigger is not null)
+        {
+            _trigger = Data.Trigger;
+            _actionEngine = Client.AutomodService.GetActionQueryEngine(Data.Planet, _trigger.Id);
+        }
+        else
+        {
+            _trigger = new AutomodTrigger(Client) { PlanetId = Data.Planet.Id };
+            _actionEngine = Client.AutomodService.GetActionQueryEngine(Data.Planet, _trigger.Id);
+        }
+
+        _actionColumns = new()
+        {
+            new()
+            {
+                Name = "Type",
+                RenderFragment = row => @<span>@row.Row.ActionType</span>
+            },
+            new()
+            {
+                Name = "Reason",
+                RenderFragment = row => @<span>@row.Row.Reason</span>
+            },
+            new()
+            {
+                Name = "Actions",
+                RenderFragment = row => @<div class="button-row">
+                        <button class="v-btn danger" @onclick="(() => RemoveAction(row.Row))">Remove</button>
+                    </div>,
+                Width = "120px"
+            }
+        };
+    }
+
+    private async Task OnSave()
+    {
+        TaskResult<AutomodTrigger> res;
+        if (_isNew)
+        {
+            _trigger.PlanetId = Data.Planet.Id;
+            res = await Client.AutomodService.CreateTriggerAsync(_trigger);
+        }
+        else
+        {
+            res = await _trigger.UpdateAsync();
+        }
+        _result = res;
+        if (res.Success)
+            Close();
+    }
+
+    private void OnAddAction()
+    {
+        // Placeholder for adding actions
+    }
+
+    private async Task RemoveAction(AutomodAction action)
+    {
+        var result = await action.DeleteAsync();
+        _result = result;
+        if (result.Success && _actionTable is not null)
+            await _actionTable.Requery();
+    }
+}

--- a/Valour/Client/_Imports.razor
+++ b/Valour/Client/_Imports.razor
@@ -41,6 +41,7 @@
 @using Valour.Client.Components.Menus.Modals
 @using Valour.Client.Components.Menus.Modals.Eco
 @using Valour.Client.Components.Menus.Modals.Planets.Edit.EditRoles
+@using Valour.Client.Components.Menus.Modals.Planets.Edit.Moderation
 @using Valour.Client.Components.Menus.Modals.BigMenu
 @using Valour.Client.Components.Menus.Modals.Channels
 @using Valour.Client.Components.Menus.Modals.Channels.Create

--- a/Valour/Sdk/Services/AutomodService.cs
+++ b/Valour/Sdk/Services/AutomodService.cs
@@ -27,4 +27,7 @@ public class AutomodService : ServiceBase
 
     public ModelQueryEngine<AutomodTrigger> GetTriggerQueryEngine(Planet planet) =>
         new ModelQueryEngine<AutomodTrigger>(planet.Node, $"api/planets/{planet.Id}/automod/triggers/query");
+
+    public ModelQueryEngine<AutomodAction> GetActionQueryEngine(Planet planet, Guid triggerId) =>
+        new ModelQueryEngine<AutomodAction>(planet.Node, $"api/planets/{planet.Id}/automod/triggers/{triggerId}/actions/query");
 }


### PR DESCRIPTION
## Summary
- add AutomodTriggerModal using BasicModalLayout
- list planet automod triggers via `QueryTable` with actions
- hook new modal into the moderation menu
- expose action query engine in `AutomodService`
- update imports for new moderation components

## Testing
- `dotnet test --no-restore` *(fails: `dotnet` not found)*