### PR TITLE
Improve Automod modals

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
@@ -1,0 +1,128 @@
+@inherits Modal<AutomodActionModal.ModalParams>
+@using Valour.Sdk.Models
+@using Valour.Shared.Models.Staff
+@inject ValourClient Client
+
+<BasicModalLayout Title="@(_isNew ? "Add Action" : "Edit Action")" Icon="lightning-fill" MaxWidth="400px">
+    <MainArea>
+        <div class="form-group mt-2">
+            <label>Type</label>
+            <select class="form-control" @bind="_action.ActionType">
+                @foreach (AutomodActionType t in Enum.GetValues<AutomodActionType>())
+                {
+                    <option value="@t">@t</option>
+                }
+            </select>
+        </div>
+
+        @if (ShowReason)
+        {
+            <div class="form-group mt-2">
+                <label>Reason</label>
+                <input class="form-control" @bind="_action.Reason" />
+            </div>
+        }
+
+        @if (ShowExpires)
+        {
+            <div class="form-group mt-2">
+                <label>Duration Minutes (0 for permanent)</label>
+                <InputNumber class="form-control" TValue="int" @bind-Value="_duration" />
+            </div>
+        }
+
+        @if (ShowRole)
+        {
+            <div class="form-group mt-2">
+                <label>Role</label>
+                <select class="form-control" @bind="_selectedRoleId">
+                    @foreach (var role in Data.Planet.Roles)
+                    {
+                        <option value="@role.Id">@role.Name</option>
+                    }
+                </select>
+            </div>
+        }
+
+        @if (ShowMessage)
+        {
+            <div class="form-group mt-2">
+                <label>Message</label>
+                <textarea class="form-control" @bind="_action.Message"></textarea>
+            </div>
+        }
+
+        <ResultLabel Result="@_result" />
+    </MainArea>
+    <ButtonArea>
+        <div class="basic-modal-buttons">
+            <button class="v-btn" @onclick="Close">Cancel</button>
+            <button class="v-btn primary" @onclick="OnSave">Save</button>
+        </div>
+    </ButtonArea>
+</BasicModalLayout>
+
+@code {
+    public class ModalParams
+    {
+        public Planet Planet { get; set; }
+        public AutomodTrigger Trigger { get; set; }
+        public AutomodAction? Action { get; set; }
+        public Func<Task>? OnSaved { get; set; }
+    }
+
+    private AutomodAction _action;
+    private bool _isNew;
+    private int _duration;
+    private long _selectedRoleId;
+    private ITaskResult _result;
+
+    protected override void OnInitialized()
+    {
+        _isNew = Data.Action is null;
+        if (Data.Action is not null)
+        {
+            _action = Data.Action;
+            _selectedRoleId = _action.RoleId ?? 0;
+            _duration = _action.Expires.HasValue ?
+                (int)Math.Ceiling((_action.Expires.Value - DateTime.UtcNow).TotalMinutes) : 0;
+        }
+        else
+        {
+            _action = new AutomodAction(Client)
+            {
+                PlanetId = Data.Planet.Id,
+                TriggerId = Data.Trigger.Id,
+                Reason = string.Empty,
+                Message = string.Empty
+            };
+        }
+    }
+
+    private bool ShowReason => _action.ActionType == AutomodActionType.Kick || _action.ActionType == AutomodActionType.Ban;
+    private bool ShowExpires => _action.ActionType == AutomodActionType.Ban;
+    private bool ShowRole => _action.ActionType == AutomodActionType.AddRole || _action.ActionType == AutomodActionType.RemoveRole;
+    private bool ShowMessage => _action.ActionType == AutomodActionType.Respond;
+
+    private async Task OnSave()
+    {
+        if (ShowRole)
+            _action.RoleId = _selectedRoleId;
+        if (ShowExpires)
+            _action.Expires = _duration > 0 ? DateTime.UtcNow.AddMinutes(_duration) : null;
+
+        TaskResult<AutomodAction> res;
+        if (_isNew)
+            res = await Client.AutomodService.CreateActionAsync(_action);
+        else
+            res = await _action.UpdateAsync();
+
+        _result = res;
+        if (res.Success)
+        {
+            if (Data.OnSaved is not null)
+                await Data.OnSaved.Invoke();
+            Close();
+        }
+    }
+}

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
@@ -9,10 +9,13 @@
             <label>Name</label>
             <input class="form-control" @bind="_trigger.Name" />
         </div>
-        <div class="form-group mt-2">
-            <label>Trigger Words (comma separated)</label>
-            <input class="form-control" @bind="_trigger.TriggerWords" />
-        </div>
+        @if (ShowTriggerWords)
+        {
+            <div class="form-group mt-2">
+                <label>@TriggerWordsLabel</label>
+                <input class="form-control" @bind="_trigger.TriggerWords" />
+            </div>
+        }
         <div class="form-group mt-2">
             <label>Type</label>
             <select class="form-control" @bind="_trigger.Type">
@@ -57,6 +60,16 @@
     private QueryTable<AutomodAction> _actionTable;
     private List<ColumnDefinition<AutomodAction>> _actionColumns;
     private ModelQueryEngine<AutomodAction> _actionEngine;
+
+    private bool ShowTriggerWords =>
+        _trigger.Type == AutomodTriggerType.Blacklist || _trigger.Type == AutomodTriggerType.Command;
+
+    private string TriggerWordsLabel => _trigger.Type switch
+    {
+        AutomodTriggerType.Blacklist => "Trigger Words (comma separated)",
+        AutomodTriggerType.Command => "Command Name",
+        _ => string.Empty
+    };
 
     protected override void OnInitialized()
     {
@@ -114,7 +127,18 @@
 
     private void OnAddAction()
     {
-        // Placeholder for adding actions
+        var data = new AutomodActionModal.ModalParams
+        {
+            Planet = Data.Planet,
+            Trigger = _trigger,
+            Action = null,
+            OnSaved = async () =>
+            {
+                if (_actionTable is not null)
+                    await _actionTable.Requery();
+            }
+        };
+        ModalRoot.OpenModal<Moderation.AutomodActionModal>(data);
     }
 
     private async Task RemoveAction(AutomodAction action)


### PR DESCRIPTION
## Summary
- only show trigger words when needed
- add modal for creating automod actions with context-aware fields

## Testing
- `npm test` *(fails: Error: no test specified)*