### PR TITLE
Fix automod trigger creation

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
@@ -1,6 +1,8 @@
 @inherits Modal<AutomodActionModal.ModalParams>
 @using Valour.Sdk.Models
 @using Valour.Shared.Models.Staff
+@using Valour.Shared
+@using System
 @inject ValourClient Client
 
 <BasicModalLayout Title="@(_isNew ? "Add Action" : "Edit Action")" Icon="lightning-fill" MaxWidth="400px">
@@ -69,6 +71,8 @@
         public AutomodTrigger Trigger { get; set; }
         public AutomodAction? Action { get; set; }
         public Func<Task>? OnSaved { get; set; }
+        public bool LocalOnly { get; set; } = false;
+        public Func<AutomodAction, Task>? OnSavedAction { get; set; }
     }
 
     private AutomodAction _action;
@@ -113,15 +117,34 @@
 
         TaskResult<AutomodAction> res;
         if (_isNew)
-            res = await Client.AutomodService.CreateActionAsync(_action);
+        {
+            if (Data.LocalOnly)
+            {
+                _action.Id = Guid.NewGuid();
+                res = TaskResult<AutomodAction>.FromData(_action);
+            }
+            else
+            {
+                res = await Client.AutomodService.CreateActionAsync(_action);
+            }
+        }
         else
+        {
             res = await _action.UpdateAsync();
+        }
 
         _result = res;
         if (res.Success)
         {
-            if (Data.OnSaved is not null)
+            if (Data.LocalOnly)
+            {
+                if (Data.OnSavedAction is not null)
+                    await Data.OnSavedAction.Invoke(_action);
+            }
+            else if (Data.OnSaved is not null)
+            {
                 await Data.OnSaved.Invoke();
+            }
             Close();
         }
     }

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
@@ -1,6 +1,7 @@
 @inherits Modal<AutomodTriggerModal.ModalParams>
 @using Valour.Sdk.Models
 @using Valour.Shared.Models.Staff
+@using Valour.Sdk.Requests
 @inject ValourClient Client
 
 <BasicModalLayout Title="@(_isNew ? "Add Trigger" : "Edit Trigger")" Icon="shield-lock-fill" MaxWidth="600px">
@@ -27,13 +28,34 @@
         </div>
 
         <p class="subtitle mt-3">ACTIONS</p>
-        <QueryTable
-            @ref="_actionTable"
-            Columns="@_actionColumns"
-            Engine="@_actionEngine"
-            Infinite="true"
-            Height="200px"
-            RowHeight="40" />
+        @if (_isNew)
+        {
+            <table class="table">
+                <thead>
+                    <tr><th>Type</th><th>Reason</th><th></th></tr>
+                </thead>
+                <tbody>
+                    @foreach (var act in _newActions)
+                    {
+                        <tr>
+                            <td>@act.ActionType</td>
+                            <td>@act.Reason</td>
+                            <td><button class="v-btn danger" @onclick="(() => RemoveNewAction(act))">Remove</button></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+        else
+        {
+            <QueryTable
+                @ref="_actionTable"
+                Columns="@_actionColumns"
+                Engine="@_actionEngine"
+                Infinite="true"
+                Height="200px"
+                RowHeight="40" />
+        }
 
         <button class="v-btn mt-2" @onclick="OnAddAction">Add Action</button>
         <ResultLabel Result="@_result" />
@@ -60,6 +82,7 @@
     private QueryTable<AutomodAction> _actionTable;
     private List<ColumnDefinition<AutomodAction>> _actionColumns;
     private ModelQueryEngine<AutomodAction> _actionEngine;
+    private List<AutomodAction> _newActions;
 
     private bool ShowTriggerWords =>
         _trigger.Type == AutomodTriggerType.Blacklist || _trigger.Type == AutomodTriggerType.Command;
@@ -82,7 +105,7 @@
         else
         {
             _trigger = new AutomodTrigger(Client) { PlanetId = Data.Planet.Id };
-            _actionEngine = Client.AutomodService.GetActionQueryEngine(Data.Planet, _trigger.Id);
+            _newActions = new();
         }
 
         _actionColumns = new()
@@ -114,7 +137,12 @@
         if (_isNew)
         {
             _trigger.PlanetId = Data.Planet.Id;
-            res = await Client.AutomodService.CreateTriggerAsync(_trigger);
+            var req = new CreateAutomodTriggerRequest
+            {
+                Trigger = _trigger,
+                Actions = _newActions
+            };
+            res = await Client.AutomodService.CreateTriggerAsync(req);
         }
         else
         {
@@ -136,6 +164,12 @@
             {
                 if (_actionTable is not null)
                     await _actionTable.Requery();
+            },
+            LocalOnly = _isNew,
+            OnSavedAction = async act =>
+            {
+                _newActions.Add(act);
+                StateHasChanged();
             }
         };
         ModalRoot.OpenModal<Moderation.AutomodActionModal>(data);
@@ -143,9 +177,21 @@
 
     private async Task RemoveAction(AutomodAction action)
     {
+        if (_isNew)
+        {
+            RemoveNewAction(action);
+            StateHasChanged();
+            return;
+        }
+
         var result = await action.DeleteAsync();
         _result = result;
         if (result.Success && _actionTable is not null)
             await _actionTable.Requery();
+    }
+
+    private void RemoveNewAction(AutomodAction action)
+    {
+        _newActions.Remove(action);
     }
 }

--- a/Valour/Sdk/Requests/CreateAutomodTriggerRequest.cs
+++ b/Valour/Sdk/Requests/CreateAutomodTriggerRequest.cs
@@ -1,0 +1,10 @@
+namespace Valour.Sdk.Requests;
+
+using System.Collections.Generic;
+using Valour.Sdk.Models;
+
+public class CreateAutomodTriggerRequest
+{
+    public AutomodTrigger Trigger { get; set; }
+    public List<AutomodAction> Actions { get; set; } = new();
+}

--- a/Valour/Sdk/Services/AutomodService.cs
+++ b/Valour/Sdk/Services/AutomodService.cs
@@ -1,5 +1,6 @@
 using Valour.Sdk.Client;
 using Valour.Sdk.ModelLogic;
+using Valour.Sdk.Requests;
 using Valour.Shared;
 
 namespace Valour.Sdk.Services;
@@ -18,6 +19,12 @@ public class AutomodService : ServiceBase
     {
         var planet = await _client.PlanetService.FetchPlanetAsync(trigger.PlanetId);
         return await planet.Node.PostAsyncWithResponse<AutomodTrigger>(trigger.BaseRoute, trigger);
+    }
+
+    public async Task<TaskResult<AutomodTrigger>> CreateTriggerAsync(CreateAutomodTriggerRequest request)
+    {
+        var planet = await _client.PlanetService.FetchPlanetAsync(request.Trigger.PlanetId);
+        return await planet.Node.PostAsyncWithResponse<AutomodTrigger>($"{request.Trigger.BaseRoute}/full", request);
     }
 
     public async Task<TaskResult<AutomodAction>> CreateActionAsync(AutomodAction action)

--- a/Valour/Server/Api/Dynamic/AutomodApi.cs
+++ b/Valour/Server/Api/Dynamic/AutomodApi.cs
@@ -3,11 +3,49 @@ using Valour.Shared.Authorization;
 using Valour.Shared.Models.Staff;
 using Valour.Server.Models;
 using Valour.Server.Services;
+using Valour.Server.Requests;
 
 namespace Valour.Server.Api.Dynamic;
 
 public class AutomodApi
 {
+    [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers/full")]
+    [UserRequired(UserPermissionsEnum.PlanetManagement)]
+    public static async Task<IResult> PostTriggerFullAsync(
+        long planetId,
+        [FromBody] CreateAutomodTriggerRequest request,
+        PlanetMemberService memberService,
+        AutomodService automodService)
+    {
+        if (request?.Trigger is null)
+            return ValourResult.BadRequest("Include trigger in body.");
+
+        var member = await memberService.GetCurrentAsync(planetId);
+        if (member is null)
+            return ValourResult.NotPlanetMember();
+
+        if (!await memberService.HasPermissionAsync(member, PlanetPermissions.Manage))
+            return ValourResult.LacksPermission(PlanetPermissions.Manage);
+
+        var trigger = request.Trigger;
+        trigger.PlanetId = planetId;
+        trigger.MemberAddedBy = member.Id;
+
+        if (request.Actions != null)
+        {
+            foreach (var act in request.Actions)
+            {
+                act.PlanetId = planetId;
+                act.MemberAddedBy = member.Id;
+            }
+        }
+
+        var result = await automodService.CreateTriggerWithActionsAsync(trigger, request.Actions ?? new());
+        if (!result.Success)
+            return ValourResult.Problem(result.Message);
+
+        return Results.Created($"api/automod/triggers/{result.Data.Id}", result.Data);
+    }
     [ValourRoute(HttpVerbs.Post, "api/planets/{planetId}/automod/triggers")]
     [UserRequired(UserPermissionsEnum.PlanetManagement)]
     public static async Task<IResult> PostTriggerAsync(

--- a/Valour/Server/Program.cs
+++ b/Valour/Server/Program.cs
@@ -128,6 +128,7 @@ public partial class Program
             new DynamicAPI<PlanetInviteApi>().RegisterRoutes(app),
             new DynamicAPI<PlanetBanApi>().RegisterRoutes(app),
             new DynamicAPI<PermissionsNodeApi>().RegisterRoutes(app),
+            new DynamicAPI<AutomodApi>().RegisterRoutes(app),
             new DynamicAPI<UserFriendApi>().RegisterRoutes(app),
             new DynamicAPI<OauthAppAPI>().RegisterRoutes(app),
             new DynamicAPI<TenorFavoriteApi>().RegisterRoutes(app),

--- a/Valour/Server/Requests/CreateAutomodTriggerRequest.cs
+++ b/Valour/Server/Requests/CreateAutomodTriggerRequest.cs
@@ -1,0 +1,10 @@
+namespace Valour.Server.Requests;
+
+using Valour.Server.Models;
+using System.Collections.Generic;
+
+public class CreateAutomodTriggerRequest
+{
+    public AutomodTrigger Trigger { get; set; }
+    public List<AutomodAction> Actions { get; set; } = new();
+}


### PR DESCRIPTION
## Summary
- register AutomodApi
- allow creating a trigger with actions in one call
- add client-side support for staging new automod actions before the trigger exists

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*