### PR TITLE
Refactor automod actions with strikes and logging

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodActionModal.razor
@@ -17,13 +17,14 @@
             </select>
         </div>
 
-        @if (ShowReason)
-        {
-            <div class="form-group mt-2">
-                <label>Reason</label>
-                <input class="form-control" @bind="_action.Reason" />
-            </div>
-        }
+        <div class="form-group mt-2">
+            <label>Strikes Required</label>
+            <InputNumber class="form-control" TValue="int" @bind-Value="_action.Strikes" />
+        </div>
+        <div class="form-group mt-2">
+            <label><input type="checkbox" @bind="_action.UseGlobalStrikes" /> Use Global Strikes</label>
+        </div>
+
 
         @if (ShowExpires)
         {
@@ -97,16 +98,16 @@
             {
                 PlanetId = Data.Planet.Id,
                 TriggerId = Data.Trigger.Id,
-                Reason = string.Empty,
-                Message = string.Empty
+                Message = string.Empty,
+                Strikes = 1,
+                UseGlobalStrikes = false
             };
         }
     }
 
-    private bool ShowReason => _action.ActionType == AutomodActionType.Kick || _action.ActionType == AutomodActionType.Ban;
     private bool ShowExpires => _action.ActionType == AutomodActionType.Ban;
     private bool ShowRole => _action.ActionType == AutomodActionType.AddRole || _action.ActionType == AutomodActionType.RemoveRole;
-    private bool ShowMessage => _action.ActionType == AutomodActionType.Respond;
+    private bool ShowMessage => _action.ActionType == AutomodActionType.Respond || _action.ActionType == AutomodActionType.Kick || _action.ActionType == AutomodActionType.Ban;
 
     private async Task OnSave()
     {

--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/Moderation/AutomodTriggerModal.razor
@@ -32,14 +32,16 @@
         {
             <table class="table">
                 <thead>
-                    <tr><th>Type</th><th>Reason</th><th></th></tr>
+                    <tr><th>Type</th><th>Message</th><th>Strikes</th><th>Global</th><th></th></tr>
                 </thead>
                 <tbody>
                     @foreach (var act in _newActions)
                     {
                         <tr>
                             <td>@act.ActionType</td>
-                            <td>@act.Reason</td>
+                            <td>@act.Message</td>
+                            <td>@act.Strikes</td>
+                            <td>@act.UseGlobalStrikes</td>
                             <td><button class="v-btn danger" @onclick="(() => RemoveNewAction(act))">Remove</button></td>
                         </tr>
                     }
@@ -117,8 +119,18 @@
             },
             new()
             {
-                Name = "Reason",
-                RenderFragment = row => @<span>@row.Row.Reason</span>
+                Name = "Message",
+                RenderFragment = row => @<span>@row.Row.Message</span>
+            },
+            new()
+            {
+                Name = "Strikes",
+                RenderFragment = row => @<span>@row.Row.Strikes</span>
+            },
+            new()
+            {
+                Name = "Global",
+                RenderFragment = row => @<span>@row.Row.UseGlobalStrikes</span>
             },
             new()
             {

--- a/Valour/Database/AutomodAction.cs
+++ b/Valour/Database/AutomodAction.cs
@@ -7,7 +7,8 @@ namespace Valour.Database;
 public class AutomodAction : ISharedAutomodAction
 {
     public Guid Id { get; set; }
-    public Guid? PriorAction { get; set; }
+    public int Strikes { get; set; }
+    public bool UseGlobalStrikes { get; set; }
     public Guid TriggerId { get; set; }
     public long MemberAddedBy { get; set; }
     public AutomodActionType ActionType { get; set; }
@@ -16,7 +17,6 @@ public class AutomodAction : ISharedAutomodAction
     public long? MessageId { get; set; }
     public long? RoleId { get; set; }
     public DateTime? Expires { get; set; }
-    public string Reason { get; set; }
     public string Message { get; set; }
 
     public static void SetupDbModel(ModelBuilder builder)
@@ -26,7 +26,6 @@ public class AutomodAction : ISharedAutomodAction
             e.ToTable("automod_actions");
             e.HasKey(x => x.Id);
             e.Property(x => x.Id).HasColumnName("id");
-            e.Property(x => x.PriorAction).HasColumnName("prior_action");
             e.Property(x => x.TriggerId).HasColumnName("trigger_id");
             e.Property(x => x.MemberAddedBy).HasColumnName("member_added_by");
             e.Property(x => x.ActionType).HasColumnName("action_type");
@@ -35,7 +34,8 @@ public class AutomodAction : ISharedAutomodAction
             e.Property(x => x.MessageId).HasColumnName("message_id");
             e.Property(x => x.RoleId).HasColumnName("role_id");
             e.Property(x => x.Expires).HasColumnName("expires");
-            e.Property(x => x.Reason).HasColumnName("reason");
+            e.Property(x => x.Strikes).HasColumnName("strikes");
+            e.Property(x => x.UseGlobalStrikes).HasColumnName("use_global_strikes");
             e.Property(x => x.Message).HasColumnName("message");
             e.HasIndex(x => x.TriggerId);
             e.HasIndex(x => x.PlanetId);

--- a/Valour/Database/AutomodLog.cs
+++ b/Valour/Database/AutomodLog.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Valour.Shared.Models.Staff;
+
+namespace Valour.Database;
+
+public class AutomodLog : ISharedAutomodLog
+{
+    public Guid Id { get; set; }
+    public long PlanetId { get; set; }
+    public Guid TriggerId { get; set; }
+    public long MemberId { get; set; }
+    public long? MessageId { get; set; }
+    public DateTime TimeTriggered { get; set; }
+
+    public static void SetupDbModel(ModelBuilder builder)
+    {
+        builder.Entity<AutomodLog>(e =>
+        {
+            e.ToTable("automod_logs");
+            e.HasKey(x => x.Id);
+            e.Property(x => x.Id).HasColumnName("id");
+            e.Property(x => x.PlanetId).HasColumnName("planet_id");
+            e.Property(x => x.TriggerId).HasColumnName("trigger_id");
+            e.Property(x => x.MemberId).HasColumnName("member_id");
+            e.Property(x => x.MessageId).HasColumnName("message_id");
+            e.Property(x => x.TimeTriggered).HasColumnName("time_triggered");
+            e.HasIndex(x => x.PlanetId);
+            e.HasIndex(x => x.TriggerId);
+            e.HasIndex(x => x.MemberId);
+        });
+    }
+}
+

--- a/Valour/Database/Context/ValourDB.cs
+++ b/Valour/Database/Context/ValourDB.cs
@@ -152,6 +152,11 @@ public partial class ValourDb : DbContext
     public DbSet<AutomodAction> AutomodActions { get; set; }
 
     /// <summary>
+    /// Table for automod trigger logs
+    /// </summary>
+    public DbSet<AutomodLog> AutomodLogs { get; set; }
+
+    /// <summary>
     /// Table for planet invites
     /// </summary>
     public DbSet<StatObject> Stats { get; set; }
@@ -279,6 +284,7 @@ public partial class ValourDb : DbContext
 
         AutomodTrigger.SetupDbModel(modelBuilder);
         AutomodAction.SetupDbModel(modelBuilder);
+        AutomodLog.SetupDbModel(modelBuilder);
 
         Valour.Database.NodeStats.SetupDbModel(modelBuilder);
         

--- a/Valour/Sdk/Models/AutomodAction.cs
+++ b/Valour/Sdk/Models/AutomodAction.cs
@@ -9,7 +9,8 @@ public class AutomodAction : ClientPlanetModel<AutomodAction, Guid>, ISharedAuto
     public override string BaseRoute => $"api/planets/{PlanetId}/automod/triggers/{TriggerId}/actions";
     public override string IdRoute => $"{BaseRoute}/{Id}";
 
-    public Guid? PriorAction { get; set; }
+    public int Strikes { get; set; }
+    public bool UseGlobalStrikes { get; set; }
     public Guid TriggerId { get; set; }
     public long MemberAddedBy { get; set; }
     public AutomodActionType ActionType { get; set; }
@@ -18,7 +19,6 @@ public class AutomodAction : ClientPlanetModel<AutomodAction, Guid>, ISharedAuto
     public long? MessageId { get; set; }
     public long? RoleId { get; set; }
     public DateTime? Expires { get; set; }
-    public string Reason { get; set; }
     public string Message { get; set; }
 
     [JsonConstructor]

--- a/Valour/Sdk/Models/AutomodLog.cs
+++ b/Valour/Sdk/Models/AutomodLog.cs
@@ -1,0 +1,31 @@
+using Valour.Sdk.Client;
+using Valour.Sdk.ModelLogic;
+using Valour.Shared.Models.Staff;
+
+namespace Valour.Sdk.Models;
+
+public class AutomodLog : ClientPlanetModel<AutomodLog, Guid>, ISharedAutomodLog
+{
+    public override string BaseRoute => $"api/planets/{PlanetId}/automod/logs";
+    public override string IdRoute => $"{BaseRoute}/{Id}";
+
+    public Guid TriggerId { get; set; }
+    public long MemberId { get; set; }
+    public long? MessageId { get; set; }
+    public DateTime TimeTriggered { get; set; }
+    public long PlanetId { get; set; }
+
+    [JsonConstructor]
+    private AutomodLog() : base() { }
+    public AutomodLog(ValourClient client) : base(client) { }
+
+    protected override long? GetPlanetId() => PlanetId;
+
+    public override AutomodLog AddToCache(ModelInsertFlags flags = ModelInsertFlags.None)
+    {
+        return this;
+    }
+
+    public override AutomodLog RemoveFromCache(bool skipEvents = false) => this;
+}
+

--- a/Valour/Server/Mapping/AutomodActionMapper.cs
+++ b/Valour/Server/Mapping/AutomodActionMapper.cs
@@ -9,7 +9,8 @@ public static class AutomodActionMapper
         return new AutomodAction
         {
             Id = action.Id,
-            PriorAction = action.PriorAction,
+            Strikes = action.Strikes,
+            UseGlobalStrikes = action.UseGlobalStrikes,
             TriggerId = action.TriggerId,
             MemberAddedBy = action.MemberAddedBy,
             ActionType = action.ActionType,
@@ -18,7 +19,6 @@ public static class AutomodActionMapper
             MessageId = action.MessageId,
             RoleId = action.RoleId,
             Expires = action.Expires,
-            Reason = action.Reason,
             Message = action.Message
         };
     }
@@ -30,7 +30,8 @@ public static class AutomodActionMapper
         return new Valour.Database.AutomodAction
         {
             Id = action.Id,
-            PriorAction = action.PriorAction,
+            Strikes = action.Strikes,
+            UseGlobalStrikes = action.UseGlobalStrikes,
             TriggerId = action.TriggerId,
             MemberAddedBy = action.MemberAddedBy,
             ActionType = action.ActionType,
@@ -39,7 +40,6 @@ public static class AutomodActionMapper
             MessageId = action.MessageId,
             RoleId = action.RoleId,
             Expires = action.Expires,
-            Reason = action.Reason,
             Message = action.Message
         };
     }

--- a/Valour/Server/Mapping/AutomodLogMapper.cs
+++ b/Valour/Server/Mapping/AutomodLogMapper.cs
@@ -1,0 +1,37 @@
+using Valour.Server.Models;
+
+namespace Valour.Server.Mapping;
+
+public static class AutomodLogMapper
+{
+    public static AutomodLog ToModel(this Valour.Database.AutomodLog log)
+    {
+        if (log is null)
+            return null;
+        return new AutomodLog
+        {
+            Id = log.Id,
+            PlanetId = log.PlanetId,
+            TriggerId = log.TriggerId,
+            MemberId = log.MemberId,
+            MessageId = log.MessageId,
+            TimeTriggered = log.TimeTriggered
+        };
+    }
+
+    public static Valour.Database.AutomodLog ToDatabase(this AutomodLog log)
+    {
+        if (log is null)
+            return null;
+        return new Valour.Database.AutomodLog
+        {
+            Id = log.Id,
+            PlanetId = log.PlanetId,
+            TriggerId = log.TriggerId,
+            MemberId = log.MemberId,
+            MessageId = log.MessageId,
+            TimeTriggered = log.TimeTriggered
+        };
+    }
+}
+

--- a/Valour/Server/Models/AutomodAction.cs
+++ b/Valour/Server/Models/AutomodAction.cs
@@ -5,7 +5,8 @@ namespace Valour.Server.Models;
 
 public class AutomodAction : ServerModel<Guid>, ISharedAutomodAction
 {
-    public Guid? PriorAction { get; set; }
+public int Strikes { get; set; }
+public bool UseGlobalStrikes { get; set; }
     public Guid TriggerId { get; set; }
     public long MemberAddedBy { get; set; }
     public AutomodActionType ActionType { get; set; }
@@ -14,6 +15,5 @@ public class AutomodAction : ServerModel<Guid>, ISharedAutomodAction
     public long? MessageId { get; set; }
     public long? RoleId { get; set; }
     public DateTime? Expires { get; set; }
-    public string Reason { get; set; }
     public string Message { get; set; }
 }

--- a/Valour/Server/Models/AutomodLog.cs
+++ b/Valour/Server/Models/AutomodLog.cs
@@ -1,0 +1,13 @@
+using Valour.Shared.Models.Staff;
+
+namespace Valour.Server.Models;
+
+public class AutomodLog : ServerModel<Guid>, ISharedAutomodLog
+{
+    public long PlanetId { get; set; }
+    public Guid TriggerId { get; set; }
+    public long MemberId { get; set; }
+    public long? MessageId { get; set; }
+    public DateTime TimeTriggered { get; set; }
+}
+

--- a/Valour/Shared/Models/Staff/AutomodAction.cs
+++ b/Valour/Shared/Models/Staff/AutomodAction.cs
@@ -18,10 +18,14 @@ public interface ISharedAutomodAction
     public Guid Id { get; set; }
     
     /// <summary>
-    /// Optionally, the id of the action that should be taken before this one
-    /// For example, if this action is a kick, the prior action could be a mute
+    /// How many strikes a user must have before this action fires
     /// </summary>
-    public Guid? PriorAction { get; set; }
+    public int Strikes { get; set; }
+
+    /// <summary>
+    /// If true, strikes are counted across all triggers
+    /// </summary>
+    public bool UseGlobalStrikes { get; set; }
     
     /// <summary>
     /// The id of the trigger that runs this action
@@ -63,10 +67,6 @@ public interface ISharedAutomodAction
     /// </summary>
     public DateTime? Expires { get; set; }
     
-    /// <summary>
-    /// The reason for the action
-    /// </summary>
-    public string Reason { get; set; }
     
     /// <summary>
     /// The message to send to the chat, if applicable

--- a/Valour/Shared/Models/Staff/AutomodLog.cs
+++ b/Valour/Shared/Models/Staff/AutomodLog.cs
@@ -1,0 +1,10 @@
+namespace Valour.Shared.Models.Staff;
+
+public interface ISharedAutomodLog : ISharedPlanetModel<Guid>
+{
+    Guid TriggerId { get; set; }
+    long MemberId { get; set; }
+    long? MessageId { get; set; }
+    DateTime TimeTriggered { get; set; }
+}
+


### PR DESCRIPTION
## Summary
- redesign automod action editor to use message, strikes and global option
- adjust trigger modal action list columns
- replace PriorAction/Reason with Strikes and UseGlobalStrikes
- add `AutomodLog` model across projects
- log trigger events and check strikes when executing actions

## Testing
- `./dotnet/dotnet build -c Release` *(fails: Failed to retrieve information about packages)*