### PR TITLE
Fix dropdown overlay closing and styling

### DIFF
--- a/Valour/Client/Components/Utility/CustomDropdownContent.razor
+++ b/Valour/Client/Components/Utility/CustomDropdownContent.razor
@@ -3,9 +3,9 @@
 
 @if (!_hidden)
 {
-    <div class="custom-dropdown-overlay @(IsMobile ? "mobile" : string.Empty)" style="@_style" @onclick="Close">
-        <div class="custom-dropdown-content" @onclick:stopPropagation="true">
-            <input class="dropdown-search" placeholder="Search" @bind="_search" @oninput="OnSearch" />
+    <div class="custom-dropdown-overlay @(IsMobile ? "mobile" : string.Empty)" @onclick="Close">
+        <div class="custom-dropdown-content" style="@_style" @onclick:stopPropagation="true">
+            <input class="dropdown-search v-input" placeholder="Search" @bind="_search" @oninput="OnSearch" />
             <div class="dropdown-items">
                 @foreach (var item in _filteredItems)
                 {
@@ -28,7 +28,7 @@
     private bool _hidden = true;
     private double _left;
     private double _top;
-    private string _style => IsMobile ? string.Empty : $"position: fixed; left: {_left}px; top: {_top}px;";
+    private string _style => IsMobile ? string.Empty : $"position: absolute; left: {_left}px; top: {_top}px;";
     private string _search = string.Empty;
     private List<object> _filteredItems = new();
     private CustomDropdownContentData _data;

--- a/Valour/Client/Components/Utility/CustomDropdownContent.razor.css
+++ b/Valour/Client/Components/Utility/CustomDropdownContent.razor.css
@@ -1,5 +1,10 @@
+
 .custom-dropdown-overlay {
     position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
     z-index: 10000;
 }
 


### PR DESCRIPTION
## Summary
- make dropdown overlay fill screen so clicking outside closes it
- position dropdown content relative to anchor
- use shared input style for search box

## Testing
- `npm test` *(fails: Error: no test specified)*
- `./dotnet/dotnet test Valour/Tests/Valour.Tests.csproj` *(fails: failed to restore packages due to no network)*