### PR TITLE
Feature: Add events to differentiate creations vs updates

### DIFF
--- a/Valour/Sdk/Nodes/Node.cs
+++ b/Valour/Sdk/Nodes/Node.cs
@@ -496,8 +496,18 @@ public class Node : ServiceBase // each node acts like a service
         where TModel : ClientModel<TModel>
     {
         var typeName = model.GetType().Name;
+        HubConnection.On<TModel>($"{typeName}-Create", OnModelCreate<TModel>);
         HubConnection.On<TModel, int>($"{typeName}-Update", OnModelUpdate<TModel>);
         HubConnection.On<TModel>($"{typeName}-Delete", OnModelDelete<TModel>);
+    }
+
+    /// <summary>
+    /// Specific model create event, mocks update events for compatibility
+    /// </summary>
+    private void OnModelCreate<TModel>(TModel model)
+        where TModel : ClientModel<TModel>
+    {
+        model.Sync(Client);
     }
 
     /// <summary>

--- a/Valour/Server/Services/AutomodService.cs
+++ b/Valour/Server/Services/AutomodService.cs
@@ -96,7 +96,7 @@ public class AutomodService
         // Invalidate cache
         _triggerCache.TryRemove(trigger.PlanetId, out _);
 
-        _coreHub.NotifyPlanetItemChange(trigger);
+        _coreHub.NotifyPlanetItemCreate(trigger);
         return new(true, "Success", trigger);
     }
 
@@ -131,9 +131,9 @@ public class AutomodService
         _triggerCache.TryRemove(trigger.PlanetId, out _);
         _actionCache.TryRemove(trigger.Id, out _);
 
-        _coreHub.NotifyPlanetItemChange(trigger);
+        _coreHub.NotifyPlanetItemCreate(trigger);
         foreach (var action in actions)
-            _coreHub.NotifyPlanetItemChange(action.PlanetId, action);
+            _coreHub.NotifyPlanetItemCreate(action.PlanetId, action);
 
         return new(true, "Success", trigger);
     }
@@ -220,7 +220,7 @@ public class AutomodService
         // Invalidate cache
         _actionCache.TryRemove(action.TriggerId, out _);
 
-        _coreHub.NotifyPlanetItemChange(action.PlanetId, action);
+        _coreHub.NotifyPlanetItemCreate(action.PlanetId, action);
         return new(true, "Success", action);
     }
 

--- a/Valour/Server/Services/ChannelService.cs
+++ b/Valour/Server/Services/ChannelService.cs
@@ -382,10 +382,10 @@ public class ChannelService
             if (associatedChatChannel is not null)
             {
                 hostedPlanet.UpsertChannel(associatedChatChannel);
-                _coreHub.NotifyPlanetItemChange(channel.PlanetId!.Value, associatedChatChannel);
+                _coreHub.NotifyPlanetItemCreate(channel.PlanetId!.Value, associatedChatChannel);
             }
             await _planetPermissionService.HandleChannelTopologyChange(channel.PlanetId!.Value);
-            _coreHub.NotifyPlanetItemChange(channel.PlanetId!.Value, channel);
+            _coreHub.NotifyPlanetItemCreate(channel.PlanetId!.Value, channel);
         }
 
         return TaskResult<Channel>.FromData(channel);

--- a/Valour/Server/Services/CoreHubService.cs
+++ b/Valour/Server/Services/CoreHubService.cs
@@ -213,6 +213,9 @@ public class CoreHubService
     public void NotifyVoiceChannelParticipants(long planetId, VoiceChannelParticipantsUpdate update) =>
         _ = _hub.Clients.Group($"p-{planetId}").SendAsync("Voice-Channel-Participants", update);
 
+    public void NotifyPlanetItemCreate<T>(long planetId, T model, int flags = 0) =>
+        _ = _hub.Clients.Group($"p-{planetId}").SendAsync($"{typeof(T).Name}-Create", model, flags);
+    
     public void NotifyPlanetItemChange<T>(long planetId, T model, int flags = 0) =>
         _ = _hub.Clients.Group($"p-{planetId}").SendAsync($"{typeof(T).Name}-Update", model, flags);
     

--- a/Valour/Server/Services/CoreHubService.cs
+++ b/Valour/Server/Services/CoreHubService.cs
@@ -216,6 +216,9 @@ public class CoreHubService
     public void NotifyPlanetItemChange<T>(long planetId, T model, int flags = 0) =>
         _ = _hub.Clients.Group($"p-{planetId}").SendAsync($"{typeof(T).Name}-Update", model, flags);
     
+    public async void NotifyPlanetItemCreate<T>(T model, int flags = 0) where T : ISharedPlanetModel => 
+        await _hub.Clients.Group($"p-{model.PlanetId}").SendAsync($"{typeof(T).Name}-Create", model, flags);
+    
     public async void NotifyPlanetItemChange<T>(T model, int flags = 0) where T : ISharedPlanetModel => 
         await _hub.Clients.Group($"p-{model.PlanetId}").SendAsync($"{typeof(T).Name}-Update", model, flags);
 

--- a/Valour/Server/Services/PlanetBanService.cs
+++ b/Valour/Server/Services/PlanetBanService.cs
@@ -97,7 +97,7 @@ public class PlanetBanService
         await tran.CommitAsync();
 
         // Notify of changes
-        _coreHub.NotifyPlanetItemChange(ban);
+        _coreHub.NotifyPlanetItemCreate(ban);
         _coreHub.NotifyPlanetItemDelete(target);
 
         var actorUserId = source == ModerationActionSource.Automod

--- a/Valour/Server/Services/PlanetEmojiService.cs
+++ b/Valour/Server/Services/PlanetEmojiService.cs
@@ -87,7 +87,7 @@ public class PlanetEmojiService
         hosted.UpsertEmoji(model);
 
         if (notify)
-            _coreHub.NotifyPlanetItemChange(model);
+            _coreHub.NotifyPlanetItemCreate(model);
 
         return TaskResult<PlanetEmoji>.FromData(model);
     }
@@ -122,7 +122,7 @@ public class PlanetEmojiService
 
     public void NotifyCreated(PlanetEmoji emoji)
     {
-        _coreHub.NotifyPlanetItemChange(emoji);
+        _coreHub.NotifyPlanetItemCreate(emoji);
     }
 
     public async Task<bool> AreAllIdsValidForPlanetAsync(long planetId, IEnumerable<long> ids)

--- a/Valour/Server/Services/PlanetInviteService.cs
+++ b/Valour/Server/Services/PlanetInviteService.cs
@@ -53,7 +53,7 @@ public class PlanetInviteService
             return new(false, e.Message);
         }
 
-        _coreHub.NotifyPlanetItemChange(invite);
+        _coreHub.NotifyPlanetItemCreate(invite);
 
         return new(true, "Success", invite);
     }

--- a/Valour/Server/Services/PlanetMemberService.cs
+++ b/Valour/Server/Services/PlanetMemberService.cs
@@ -378,7 +378,8 @@ public class PlanetMemberService
 
         var model = member.ToModel();
 
-        _coreHub.NotifyPlanetItemChange(model);
+        // Notify subscribers that an item has been created (Member added)
+        _coreHub.NotifyPlanetItemCreate(model);
 
         await _automodService.HandleMemberJoinAsync(model);
 

--- a/Valour/Server/Services/PlanetRoleService.cs
+++ b/Valour/Server/Services/PlanetRoleService.cs
@@ -108,7 +108,7 @@ public class PlanetRoleService
         }
 
         hostedPlanet.UpsertRole(role);
-        _coreHub.NotifyPlanetItemChange(role);
+        _coreHub.NotifyPlanetItemCreate(role);
 
         // If we bumped the default role, update cache and notify clients
         if (defaultRoleUpdated)


### PR DESCRIPTION
Adds a new event suffix "Create" to planet models which can differentiate between items being created and just being updated, while (hopefully) maintaining compatibility by simply calling `model.Sync` by default.

This will make future hooks and bots able to specifically listen for creation events instead of having to differentiate between a model creation vs update by using the snowflake/timestamp/cache, allowing for better control over actions.

Note: I haven't been able to fully test this, and would appreciate anyone who has gotten Valour set up locally to help with this. I did some digging into the code to try to find hook locations, and it appears that it's only in the Node model, but that could be incorrect.