### PR TITLE
Fix text flow for radio buttons

### DIFF
--- a/Valour/Client/wwwroot/css/app.css
+++ b/Valour/Client/wwwroot/css/app.css
@@ -876,8 +876,8 @@ input:checked + .slider:before {
 }
 
 .switch-radio {
-    width: 24px;
-    line-height: 6pt;
+    width: max-content;
+    line-height: 20pt;
     margin-left: 30px;
     cursor: pointer;
 }


### PR DESCRIPTION
Discovered a funny bug that breaks long text flows.

Before:
<img width="152" height="124" alt="image" src="https://github.com/user-attachments/assets/840ebcce-8aae-4bbf-a4a0-7e14ba70ef0f" />

After:
<img width="187" height="121" alt="image" src="https://github.com/user-attachments/assets/7b15ae0d-2b3e-4b53-a608-f9ab7af16db0" />
