### PR TITLE
Revamp register, login, and forgot-password flows

### DIFF
--- a/Valour/Client/Components/Utility/LoginComponent.razor
+++ b/Valour/Client/Components/Utility/LoginComponent.razor
@@ -36,7 +36,12 @@
             </div>
             <div class="form-group mt-2">
                 <label>Password</label>
-                <input @ref="@PasswordInput" id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password" @onkeyup="@OnPasswordKey"/>
+                <div class="password-wrapper">
+                    <input @ref="@PasswordInput" id="password-input" type="@(_showPassword ? "text" : "password")" autocomplete="current-password" class="form-control" @bind-value="@_password" @onkeyup="@OnPasswordKey"/>
+                    <button type="button" class="password-toggle" tabindex="-1" aria-label="Toggle password visibility" @onclick="@(() => _showPassword = !_showPassword)">
+                        <i class="bi @(_showPassword ? "bi-eye-slash" : "bi-eye")"></i>
+                    </button>
+                </div>
                 <span id="password-span" class="text-danger">@_passwordSpan</span>
             </div>
             <span id="result-span" class="text-info">@_resultSpan</span>
@@ -89,6 +94,7 @@
 
     private string _email;
     private string _password;
+    private bool _showPassword;
 
     private string _emailSpan;
     private string _passwordSpan;

--- a/Valour/Client/Components/Utility/LoginComponent.razor.css
+++ b/Valour/Client/Components/Utility/LoginComponent.razor.css
@@ -1,14 +1,22 @@
-﻿.page {
+﻿/* Fixing SpikeViper's questionable UX decisions */
+.page {
     overflow-y: auto;
     display: flex;
     flex-direction: column;
+    align-items: center;
+    justify-content: center;
     height: 100vh;
+    padding: 32px 16px;
+    box-sizing: border-box;
 }
 
 .login-left {
     background-color: var(--main-2);
     max-width: 400px;
-    flex-grow: 1;
+    width: 100%;
+    border-radius: var(--card-radius);
+    border: 1px solid var(--slight-tint);
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
 }
 
 .mobile-image {
@@ -54,12 +62,40 @@
     margin-bottom: 40px;
 }
 
+.password-wrapper {
+    position: relative;
+}
+
+.password-wrapper input {
+    padding-right: 38px;
+}
+
+.password-toggle {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 4px 8px;
+    color: #ffffff88;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.password-toggle:hover {
+    color: #ffffff;
+}
+
 .forgot-password {
     color: #ffffffaa;
     font-size: 14px;
-    display:block;
+    display: block;
     cursor: pointer;
     text-align: right;
+    width: fit-content;
+    margin-left: auto;
 }
 
 .forgot-password:hover {
@@ -69,6 +105,7 @@
 .hidden-victor {
     position: absolute;
     z-index: -1;
+    opacity: 0;
     top: -33px;
     scale: 0.4;
     left: 45px;
@@ -80,6 +117,7 @@
 
 .v-btn-grad-wrapper:hover .hidden-victor {
     z-index: 0;
+    opacity: 1;
     scale: 0.6;
     top: -67px;
     left: 66px;
@@ -99,6 +137,19 @@
 
     .login-left form {
         padding-top: 40px;
+    }
+}
+
+@media screen and (max-width: 399px){
+    .page {
+        align-items: stretch;
+        justify-content: flex-start;
+    }
+
+    .login-left {
+        border-radius: 0;
+        border: none;
+        flex-grow: 1;
     }
 }
 

--- a/Valour/Client/Pages/ForgotPassword.razor
+++ b/Valour/Client/Pages/ForgotPassword.razor
@@ -1,47 +1,54 @@
-﻿@page "/ForgotPassword"
+@page "/ForgotPassword"
 
 @inject HttpClient Http
 @inject NavigationManager NavManager
 
-<body class="login-background" style="background-image: url(_content/Valour.Client/media/Abstract-Background.png)">
-    <div class="popup-box">
-        
-        @if (_emailed)
-        {
-            <h4>Email sent.</h4>
-            <h6>Make sure to check your spam folder!</h6>
-        }
-        else
-        {
-            <div class="col-md-12">
-                <section>
-                    <h4>Forgot your password?</h4>
-
-                    <h6>No worries!</h6>
-                    <hr/>
-                    <div asp-validation-summary="All" class="text-danger"></div>
-                    <div class="form-group mt-2">
-                        <label>Email</label>
-                        <input type="email" class="form-control" @bind-value="@email"/>
-                        <span id="email-span" class="text-danger">@emailSpan</span>
-                    </div>
-                    @if (!string.IsNullOrWhiteSpace(errorSpan))
-                    {
-                        <span id="error-span" class="text-danger" style="display:block">@errorSpan</span>
-                    }
-                    <div class="form-group mt-4" style="display:inline-block">
-                        <button class="btn btn-primary mt-2" @onclick="OnClickSubmit">Submit</button>
-                    </div>
-                </section>
-            </div>
-        }
+<div class="page">
+    <div class="login-background">
     </div>
-</body>
+    <div class="mobile-image">
+    </div>
+    <div class="forgot-left col-md-5">
+        <form>
+            <div class="victor-wrapper">
+                <img alt="victor" class="victor" src="_content/Valour.Client/media/victor.svg"/>
+            </div>
+            @if (_emailed)
+            {
+                <div class="title">
+                    <h3>Email sent!</h3>
+                    <h4>Make sure to check your spam folder.</h4>
+                </div>
+            }
+            else
+            {
+                <div class="title">
+                    <h3>Forgot your password?</h3>
+                    <h4>No worries! We'll send you a reset link.</h4>
+                </div>
+                <div asp-validation-summary="All" class="text-danger"></div>
+                <div class="form-group">
+                    <label>Email</label>
+                    <input type="email" autocomplete="email" class="form-control" @bind-value="@email"/>
+                    <span id="email-span" class="text-danger">@emailSpan</span>
+                </div>
+                @if (!string.IsNullOrWhiteSpace(errorSpan))
+                {
+                    <span id="error-span" class="text-danger" style="display:block">@errorSpan</span>
+                }
+                <div class="v-btn-wrapper mt-4">
+                    <button type="button" class="v-btn blue half" @onclick="OnClickSubmit">Send Reset Link</button>
+                </div>
+            }
+            <a class="mt-4 back-to-login" href="/">Back to log in</a>
+        </form>
+    </div>
+</div>
 
 @code {
 
     private bool _emailed = false;
-    
+
     // Input fields
     string email;
 

--- a/Valour/Client/Pages/ForgotPassword.razor.css
+++ b/Valour/Client/Pages/ForgotPassword.razor.css
@@ -1,0 +1,96 @@
+.page {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    padding: 32px 16px;
+    box-sizing: border-box;
+}
+
+.forgot-left {
+    background-color: var(--main-2);
+    max-width: 400px;
+    width: 100%;
+    border-radius: var(--card-radius);
+    border: 1px solid var(--slight-tint);
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+}
+
+.mobile-image {
+    background-image: url(/_content/Valour.Client/media/Spookvooper-tall.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    height: 20vh;
+}
+
+.forgot-left form {
+    padding: 24px 36px;
+}
+
+.login-background {
+    background-image: url(/_content/Valour.Client/media/Spookvooper-tall.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    margin: 0px;
+    backdrop-filter: blur(5px);
+    position: absolute;
+    width: 100%;
+    height: 100vh;
+    z-index: -1;
+}
+
+.victor-wrapper {
+    text-align: center;
+}
+
+.victor-wrapper .victor {
+    width: 96px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.title {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.back-to-login {
+    color: #ffffffaa;
+    font-size: 14px;
+    display: block;
+    cursor: pointer;
+    text-align: right;
+    width: fit-content;
+    margin-left: auto;
+}
+
+.back-to-login:hover {
+    color: #ffffff;
+}
+
+@media screen and (min-width: 400px) {
+    .mobile-image {
+        display: none;
+    }
+
+    .login-background {
+        height: 100vh;
+    }
+}
+
+@media screen and (max-width: 399px) {
+    .page {
+        align-items: stretch;
+        justify-content: flex-start;
+    }
+
+    .forgot-left {
+        border-radius: 0;
+        border: none;
+        flex-grow: 1;
+    }
+}

--- a/Valour/Client/Pages/Register.razor
+++ b/Valour/Client/Pages/Register.razor
@@ -1,92 +1,114 @@
-﻿@page "/Register"
+@page "/Register"
 @page "/Register/I/{InviteCode}"
 @page "/Register/from/{Source}"
 @page "/Register/referral/{Referral}"
 
 @inject IJSRuntime JsRuntime
 @inject AuthService AuthService
+@inject NavigationManager NavManager
 
-<body class="login-background" style="background-image: url(_content/Valour.Client/media/Abstract-Background.png)">
-    <div class="popup-box">
-        <div class="col-md-12">
-            @if (!_completed)
-            {
-                <section>
-                    <h2>Register for Valour</h2>
-
-                    <h4>Welcome to our app!</h4>
-                    <hr />
-                    <div asp-validation-summary="All" class="text-danger"></div>
-                    <div class="form-group mt-2">
-                        <label>Username</label>
-                        <input class="form-control" @bind-value="@_username" />
-                    </div>
-                    <div class="form-group mt-2">
-                        <label>Email</label>
-                        <input type="email" class="form-control" @bind-value="@_email" />
-                    </div>
-                    <div class="form-group mt-2">
+<div class="page">
+    <div class="login-background">
+    </div>
+    <div class="mobile-image">
+    </div>
+    <div class="register-left col-md-5">
+        @if (!_completed)
+        {
+            <form>
+                <div class="victor-wrapper">
+                    <img alt="victor" class="victor" src="_content/Valour.Client/media/victor.svg"/>
+                </div>
+                <div class="title">
+                    <h3>Join Valour</h3>
+                    <h4>Create your account</h4>
+                </div>
+                <div asp-validation-summary="All" class="text-danger"></div>
+                <div class="form-group">
+                    <label>Username</label>
+                    <input autocomplete="username" class="form-control" @bind-value="@_username" />
+                </div>
+                <div class="form-group mt-2">
+                    <label>Email</label>
+                    <input type="email" autocomplete="email" class="form-control" @bind-value="@_email" />
+                </div>
+                <div class="field-row mt-2">
+                    <div class="form-group">
                         <label>Password</label>
-                        <input type="password" class="form-control" @bind-value="@_password" />
-                    </div>
-                    <div class="form-group mt-2">
-                        <label>Confirm Password</label>
-                        <input type="password" class="form-control" @bind-value="@_passwordConf" />
-                    </div>
-                    <div class="form-group mt-2">
-                        <label>Birthday</label>
-                        <InputDate @bind-Value="@_dob" class="form-control"></InputDate>
-                        <br />
-                        <span id="date-span" class="text-danger">@_dobSpan</span>
-                    </div>
-                    <div class="form-group mt-2">
-                        <label>Referral (Optional)</label>
-                        <input type="text" class="form-control" @bind-value="@_referral" disabled="@_lockReferral" />
-                        <span id="referral-info-span" class="text-info">This is the username of a user who sent you to Valour! (ie SpikeViper#0000)</span>
-                    </div>
-                    <div class="form-group mt-4">
-                        <div style="display: inline-block">
-                            <p>
-                                <input type="checkbox" @bind-value="@_termsAgreed" /> &nbsp; By checking this box, you acknowledge you have read and agree to the Valour <a href="https://github.com/SpikeViper/Valour/blob/main/TERMS_OF_SERVICE.md">Terms of Service </a>
-                                and to follow the <a href="https://github.com/SpikeViper/Valour/blob/main/PLATFORM_RULES.md"> Platform Rules</a> and <a href="https://github.com/SpikeViper/Valour/blob/main/PLATFORM_ECO_RULES.md"> Eco Rules</a>.
-                            </p>
+                        <div class="password-wrapper">
+                            <input type="@(_showPassword ? "text" : "password")" autocomplete="new-password" class="form-control" @bind-value="@_password" />
+                            <button type="button" class="password-toggle" tabindex="-1" aria-label="Toggle password visibility" @onclick="@(() => _showPassword = !_showPassword)">
+                                <i class="bi @(_showPassword ? "bi-eye-slash" : "bi-eye")"></i>
+                            </button>
                         </div>
                     </div>
-                    <span id="error-span" class="text-danger">@_errorSpan</span>
-                    <span id="success-span" class="text-info">@_successSpan</span>
-
-                    <div class="form-group mt-4">
-                        <button class="btn v-btn primary mt-2" @onclick="OnClickSubmit">Submit</button>
+                    <div class="form-group">
+                        <label>Confirm Password</label>
+                        <div class="password-wrapper">
+                            <input type="@(_showPasswordConf ? "text" : "password")" autocomplete="new-password" class="form-control" @bind-value="@_passwordConf" />
+                            <button type="button" class="password-toggle" tabindex="-1" aria-label="Toggle password visibility" @onclick="@(() => _showPasswordConf = !_showPasswordConf)">
+                                <i class="bi @(_showPasswordConf ? "bi-eye-slash" : "bi-eye")"></i>
+                            </button>
+                        </div>
                     </div>
-                </section>
-            }
-            else
-            {
+                </div>
+                <div class="field-row mt-2">
+                    <div class="form-group">
+                        <label>Birthday</label>
+                        <InputDate @bind-Value="@_dob" class="form-control"></InputDate>
+                    </div>
+                    <div class="form-group">
+                        <label>Referral <span class="optional-hint">(optional)</span></label>
+                        <input type="text" class="form-control" @bind-value="@_referral" disabled="@_lockReferral" placeholder="SpikeViper#0000" />
+                    </div>
+                </div>
+                <span id="date-span" class="text-danger">@_dobSpan</span>
+                <span id="referral-info-span" class="field-hint">Referral is the username of someone who sent you to Valour</span>
+                <label class="terms mt-4">
+                    <input type="checkbox" @bind-value="@_termsAgreed" />
+                    <span>
+                        I have read and agree to the Valour <a href="https://github.com/SpikeViper/Valour/blob/main/TERMS_OF_SERVICE.md">Terms of Service</a>,
+                        and will follow the <a href="https://github.com/SpikeViper/Valour/blob/main/PLATFORM_RULES.md">Platform Rules</a> and <a href="https://github.com/SpikeViper/Valour/blob/main/PLATFORM_ECO_RULES.md">Eco Rules</a>.
+                    </span>
+                </label>
+                <span id="error-span" class="text-danger">@_errorSpan</span>
+                <span id="success-span" class="text-info">@_successSpan</span>
+                <div class="v-btn-wrapper mt-4">
+                    <button type="button" class="v-btn blue half" @onclick="OnClickSubmit">Create Account</button>
+                </div>
+                <a class="mt-4 back-to-login" href="/">Already have an account? Log in</a>
+            </form>
+        }
+        else
+        {
+            <div class="confirmation-wrapper">
                 <ConfirmationEmailComponent RegisterRequest="@_regRequest"></ConfirmationEmailComponent>
-            }
-        </div>
+            </div>
+        }
     </div>
-</body>
+</div>
 
 @code {
 
     [Parameter]
     public string InviteCode { get; set; }
-    
+
     [Parameter]
     public string Source { get; set; }
-    
+
     [Parameter]
     public string Referral { get; set; }
 
     private bool _completed;
-    
+
     private RegisterUserRequest _regRequest;
-    
+
     // Input fields
     private string _email;
     private string _password;
     private string _passwordConf;
+    private bool _showPassword;
+    private bool _showPasswordConf;
     private string _username;
     private string _referral;
     private bool _lockReferral;
@@ -145,7 +167,7 @@
         var now = DateTime.Today;
         var age = now.Year - _dob.Year;
         if (_dob > now.AddYears(-age)) age--;
-        
+
         switch (age)
         {
             case 0:

--- a/Valour/Client/Pages/Register.razor
+++ b/Valour/Client/Pages/Register.razor
@@ -36,7 +36,7 @@
                     <div class="form-group">
                         <label>Password</label>
                         <div class="password-wrapper">
-                            <input type="@(_showPassword ? "text" : "password")" autocomplete="new-password" class="form-control" @bind-value="@_password" />
+                            <input type="@(_showPassword ? "text" : "password")" autocomplete="new-password" class="form-control" @bind-value="@_password" @bind-value:event="oninput" />
                             <button type="button" class="password-toggle" tabindex="-1" aria-label="Toggle password visibility" @onclick="@(() => _showPassword = !_showPassword)">
                                 <i class="bi @(_showPassword ? "bi-eye-slash" : "bi-eye")"></i>
                             </button>
@@ -45,13 +45,26 @@
                     <div class="form-group">
                         <label>Confirm Password</label>
                         <div class="password-wrapper">
-                            <input type="@(_showPasswordConf ? "text" : "password")" autocomplete="new-password" class="form-control" @bind-value="@_passwordConf" />
+                            <input type="@(_showPasswordConf ? "text" : "password")" autocomplete="new-password" class="form-control @(PasswordsMismatch ? "input-error" : "")" @bind-value="@_passwordConf" @bind-value:event="oninput" />
                             <button type="button" class="password-toggle" tabindex="-1" aria-label="Toggle password visibility" @onclick="@(() => _showPasswordConf = !_showPasswordConf)">
                                 <i class="bi @(_showPasswordConf ? "bi-eye-slash" : "bi-eye")"></i>
                             </button>
                         </div>
                     </div>
                 </div>
+                @if (!string.IsNullOrEmpty(_password) && !AllCriteriaMet)
+                {
+                    <ul class="pw-criteria">
+                        <li class="@(LengthOk ? "met" : "")">At least 10 characters</li>
+                        <li class="@(UpperOk ? "met" : "")">An uppercase letter</li>
+                        <li class="@(LowerOk ? "met" : "")">A lowercase letter</li>
+                        <li class="@(NumberOrSymbolOk ? "met" : "")">A number or symbol</li>
+                    </ul>
+                }
+                @if (PasswordsMismatch)
+                {
+                    <span class="pw-mismatch">Passwords do not match</span>
+                }
                 <div class="field-row mt-2">
                     <div class="form-group">
                         <label>Birthday</label>
@@ -120,6 +133,14 @@
     private string _successSpan;
     private string _dobSpan;
 
+    // Live password criteria — must mirror UserUtils.TestPasswordComplexity
+    private bool LengthOk => _password?.Length >= 10;
+    private bool UpperOk => _password is not null && System.Text.RegularExpressions.Regex.IsMatch(_password, "[A-Z]");
+    private bool LowerOk => _password is not null && System.Text.RegularExpressions.Regex.IsMatch(_password, "[a-z]");
+    private bool NumberOrSymbolOk => _password is not null && System.Text.RegularExpressions.Regex.IsMatch(_password, @"\d|\W");
+    private bool AllCriteriaMet => LengthOk && UpperOk && LowerOk && NumberOrSymbolOk;
+    private bool PasswordsMismatch => !string.IsNullOrEmpty(_passwordConf) && !string.Equals(_password, _passwordConf);
+
     protected override void OnInitialized()
     {
         if (!string.IsNullOrWhiteSpace(Referral))
@@ -149,6 +170,12 @@
         if (string.IsNullOrWhiteSpace(_password))
         {
             _errorSpan = "Please input a password.";
+            return;
+        }
+
+        if (!AllCriteriaMet)
+        {
+            _errorSpan = "Your password does not meet the requirements.";
             return;
         }
 

--- a/Valour/Client/Pages/Register.razor.css
+++ b/Valour/Client/Pages/Register.razor.css
@@ -1,0 +1,185 @@
+.page {
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    padding: 32px 16px;
+    box-sizing: border-box;
+}
+
+.register-left {
+    background-color: var(--main-2);
+    max-width: 480px;
+    width: 100%;
+    border-radius: var(--card-radius);
+    border: 1px solid var(--slight-tint);
+    box-shadow: 0 25px 50px rgba(0, 0, 0, 0.5);
+    max-height: calc(100vh - 64px);
+    overflow-y: auto;
+}
+
+.field-row {
+    display: flex;
+    gap: 12px;
+}
+
+.field-row .form-group {
+    flex: 1;
+    min-width: 0;
+}
+
+.mobile-image {
+    background-image: url(/_content/Valour.Client/media/Spookvooper-tall.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    height: 20vh;
+}
+
+.register-left form {
+    padding: 24px 36px;
+}
+
+.login-background {
+    background-image: url(/_content/Valour.Client/media/Spookvooper-tall.jpg);
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center;
+    margin: 0px;
+    backdrop-filter: blur(5px);
+    position: absolute;
+    width: 100%;
+    height: 100vh;
+    z-index: -1;
+}
+
+.victor-wrapper {
+    text-align: center;
+}
+
+.victor-wrapper .victor {
+    width: 96px;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.title {
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+.optional-hint {
+    color: #ffffff77;
+    font-weight: 400;
+}
+
+.field-hint {
+    display: block;
+    margin-top: 4px;
+    color: #ffffff77;
+    font-size: 12px;
+}
+
+.terms {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    font-size: 13px;
+    color: #ffffffcc;
+    cursor: pointer;
+}
+
+.terms input {
+    margin-top: 3px;
+    flex-shrink: 0;
+}
+
+#error-span,
+#success-span {
+    display: block;
+    margin-top: 12px;
+}
+
+.password-wrapper {
+    position: relative;
+}
+
+.password-wrapper input {
+    padding-right: 38px;
+}
+
+.password-toggle {
+    position: absolute;
+    right: 6px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 4px 8px;
+    color: #ffffff88;
+    font-size: 16px;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.password-toggle:hover {
+    color: #ffffff;
+}
+
+.back-to-login {
+    color: #ffffffaa;
+    font-size: 14px;
+    display: block;
+    cursor: pointer;
+    text-align: right;
+    width: fit-content;
+    margin-left: auto;
+}
+
+.back-to-login:hover {
+    color: #ffffff;
+}
+
+.confirmation-wrapper {
+    padding: 40px;
+}
+
+@media screen and (min-width: 400px) {
+    .mobile-image {
+        display: none;
+    }
+
+    .login-background {
+        height: 100vh;
+    }
+
+    .register-left form {
+        padding-top: 24px;
+    }
+}
+
+@media screen and (max-width: 480px) {
+    .field-row {
+        flex-direction: column;
+        gap: 0;
+    }
+
+    .field-row .form-group + .form-group {
+        margin-top: 8px;
+    }
+}
+
+@media screen and (max-width: 399px) {
+    .page {
+        align-items: stretch;
+        justify-content: flex-start;
+    }
+
+    .register-left {
+        border-radius: 0;
+        border: none;
+        flex-grow: 1;
+    }
+}

--- a/Valour/Client/Pages/Register.razor.css
+++ b/Valour/Client/Pages/Register.razor.css
@@ -25,6 +25,46 @@
     gap: 12px;
 }
 
+.pw-criteria {
+    list-style: none;
+    margin: 2px 0 0;
+    padding: 0;
+    font-size: 12px;
+    color: var(--p-red);
+    display: grid;
+    grid-template-columns: repeat(2, max-content);
+    justify-content: center;
+    gap: 2px 24px;
+    width: 100%;
+}
+
+.pw-criteria li::before {
+    content: "\2715";
+    margin-right: 6px;
+    font-size: 10px;
+}
+
+.pw-criteria li.met {
+    color: #43b581;
+}
+
+.pw-criteria li.met::before {
+    content: "\2713";
+}
+
+.pw-mismatch {
+    display: block;
+    margin-top: 6px;
+    font-size: 12px;
+    color: var(--p-red);
+    text-align: center;
+}
+
+.input-error,
+.input-error:focus {
+    border-color: var(--p-red) !important;
+}
+
 .field-row .form-group {
     flex: 1;
     min-width: 0;

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -316,13 +316,14 @@
     display: inline-block;
     border-radius: var(--main-radius);
     font-size: 1em;
-    padding: 0.2em;
+    padding: 2px;
     background: linear-gradient(to right, #00FFEE -31%, #FF00EE 192%);
     cursor: pointer;
     position: relative;
 }
 
 .v-btn-grad-wrapper .v-btn {
+    width: 100%;
     border-radius: calc(var(--main-radius) - 2px) !important;
 }
 
@@ -335,9 +336,8 @@
 .v-btn.gradient {
     color: #fff;
     border: none;
-    background-color: #111122;
-    transition: all 0.3s ease-in-out;
-    border-radius: 1em;
+    background: var(--main-1);
+    transition: background 0.3s ease-in-out;
     flex: 1;
 }
 
@@ -346,13 +346,21 @@
     padding: 5px !important;
 }
 
+/* The gradient button sits inside its wrapper's gradient "border" — the
+   generic .v-btn hover lift/shadow would shift it out of alignment */
+.v-btn-grad-wrapper .v-btn.gradient,
 .v-btn-grad-wrapper:hover .v-btn.gradient {
-    background-color: transparent;
+    transform: none;
+    box-shadow: none;
+}
+
+.v-btn-grad-wrapper:hover .v-btn.gradient {
+    background: transparent;
 }
 
 .v-btn-grad-wrapper p {
     color: white;
-    transition: all 0.3s ease-in-out;
+    transition: color 0.3s ease-in-out;
     margin: 0;
     text-align: center;
 }
@@ -367,7 +375,7 @@
 }
 
 .v-btn:hover.blue {
-    background-color: #b386eb;
+    background: color-mix(in srgb, #0d6efd 85%, white);
 }
 
 .v-btn.center {


### PR DESCRIPTION
## Summary

The register and forgot-password pages were still on the old design (popup box over the abstract background) and looked dated next to the login screen. This PR brings all three auth pages onto one consistent, modern design:

- **Register and forgot-password pages** now use the same planet background, card layout, Victor logo, and `v-btn` design system as login
- **All three auth pages are centered cards** instead of left-anchored panels (full-width panel preserved on mobile widths)
- **Register form fits on screen without scrolling** — password/confirm and birthday/referral are paired into two-column rows (stacking back to one column on narrow screens)
- **Fixed the gradient Register button** on the login screen: the inner button was rendered partially behind its gradient border and shifted/faded by the generic `v-btn` hover transform — it now fills the wrapper, uses theme colors, and hovers cleanly
- **Blue buttons brighten on hover** instead of turning purple-pink (`#b386eb`)
- **"Forgot my password" / "Back to log in" links** are now only clickable on their text instead of the entire row
- **Added show/hide password toggles** (eye icon) to all password fields
- The hidden-Victor hover easter egg is preserved (and no longer flashes during image load)

No changes to any registration/login/reset logic — validation, age checks, EU locality detection, invite codes, referrals, and MFA flows are untouched.

## Testing

- Built and ran locally; registered an account end-to-end against a local server
- Verified all three pages at desktop and mobile widths