### PR TITLE
Fix fresh database setup: remove explicit xmin columns from initial migration

### DIFF
--- a/Valour/Database/Migrations/20250820152533_MigrateRefactor0.cs
+++ b/Valour/Database/Migrations/20250820152533_MigrateRefactor0.cs
@@ -83,8 +83,7 @@ namespace Valour.Database.Migrations
                     short_code text,
                     symbol text,
                     issued bigint NOT NULL,
-                    decimal_places integer NOT NULL,
-                    xmin xid NOT NULL
+                    decimal_places integer NOT NULL
                 );
 
                 CREATE TABLE IF NOT EXISTS node_stats (
@@ -414,8 +413,7 @@ namespace Valour.Database.Migrations
                     planet_id bigint NOT NULL,
                     planet_member_id bigint,
                     currency_id bigint NOT NULL,
-                    balance_value numeric NOT NULL,
-                    xmin xid NOT NULL
+                    balance_value numeric NOT NULL
                 );
 
                 CREATE TABLE IF NOT EXISTS messages (


### PR DESCRIPTION
## Summary

Following the README's local setup steps on a fresh PostgreSQL database currently fails at server startup:

```
Unhandled exception. Npgsql.PostgresException (0x80004005): 42701: column name "xmin" conflicts with a system column name
```

The initial migration (`20250820152533_MigrateRefactor0`) declares `xmin xid NOT NULL` columns in the raw SQL for the `currencies` and `eco_accounts` tables. `xmin` is a reserved PostgreSQL system column that exists automatically on every table, so any fresh `db.Database.Migrate()` run hits this error — every new contributor setting up locally is affected.

## Fix

Remove the two explicit `xmin` declarations. Existing deployments are unaffected (this migration has already run there), and EF Core's Npgsql provider maps `xmin` as a concurrency token from the system column without it being declared.

## Testing

- Fresh database + `dotnet run`: migrations apply cleanly and the server starts
- Verified `currencies` and `eco_accounts` tables are created correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)