### PR TITLE
Sweep the final pieces of past Settings design

### DIFF
--- a/Valour/Client/Components/Developer/BotManagementComponent.razor
+++ b/Valour/Client/Components/Developer/BotManagementComponent.razor
@@ -1,85 +1,82 @@
 @inject ValourClient Client
+<div class="editor-section">
+    <h3 class="editor-section-title">
+        <i class="bi bi-robot"></i>
+        Bot Accounts
+    </h3>
+    <p class="subtitle">Create and manage bot accounts for automation and integrations</p>
 
-<div class="bot-management-container">
-    <div class="editor-section">
-        <h3 class="editor-section-title">
-            <i class="bi bi-robot"></i>
-            Bot Accounts
-        </h3>
-        <p class="subtitle">Create and manage bot accounts for automation and integrations</p>
-
-        <div class="bot-actions">
-            <button class="v-btn primary" @onclick="OnCreateBot" disabled="@(_bots is not null && _bots.Count >= 10)">
-                <i class="bi bi-plus-circle"></i>
-                Create New Bot
-            </button>
-            @if (_bots is not null && _bots.Count >= 10)
-            {
-                <span class="limit-warning">Maximum of 10 bots reached</span>
-            }
-        </div>
-
-        @if (_bots is null)
+    <div class="bot-actions">
+        <button class="v-btn primary" @onclick="OnCreateBot" disabled="@(_bots is not null && _bots.Count >= 10)">
+            <i class="bi bi-plus-circle"></i>
+            Create New Bot
+        </button>
+        @if (_bots is not null && _bots.Count >= 10)
         {
-            <div class="loading-state">
-                <i class="bi bi-arrow-clockwise"></i>
-                <p>Loading your bots...</p>
-            </div>
-        }
-        else if (_bots.Count == 0)
-        {
-            <div class="empty-state">
-                <i class="bi bi-robot"></i>
-                <h4>No Bot Accounts</h4>
-                <p>You haven't created any bot accounts yet. Create your first bot to start building integrations with Valour.</p>
-                <button class="v-btn primary" @onclick="OnCreateBot">Create Your First Bot</button>
-            </div>
-        }
-        else
-        {
-            <div class="bots-grid">
-                @foreach (var bot in _bots)
-                {
-                    <div class="bot-card" @onclick="() => OnEditBot(bot)">
-                        <div class="bot-icon">
-                            <img src="@GetBotAvatar(bot)" alt="@bot.Name" onerror="this.src='_content/Valour.Client/media/user-icons/icon-0.webp'" />
-                        </div>
-                        <div class="bot-info">
-                            <h4 class="bot-name">@bot.Name</h4>
-                            <p class="bot-tag">#@bot.Tag</p>
-                            <p class="bot-id">ID: @bot.Id</p>
-                        </div>
-                        <div class="bot-actions-icon">
-                            <i class="bi bi-chevron-right"></i>
-                        </div>
-                    </div>
-                }
-            </div>
+            <span class="limit-warning">Maximum of 10 bots reached</span>
         }
     </div>
 
-    <div class="editor-section">
-        <h3 class="editor-section-title">
-            <i class="bi bi-info-circle"></i>
-            About Bots
-        </h3>
-        <p class="subtitle">Learn how to use bots with Valour</p>
+    @if (_bots is null)
+    {
+        <div class="loading-state">
+            <i class="bi bi-arrow-clockwise"></i>
+            <p>Loading your bots...</p>
+        </div>
+    }
+    else if (_bots.Count == 0)
+    {
+        <div class="empty-state">
+            <i class="bi bi-robot"></i>
+            <h4>No Bot Accounts</h4>
+            <p>You haven't created any bot accounts yet. Create your first bot to start building integrations with Valour.</p>
+            <button class="v-btn primary" @onclick="OnCreateBot">Create Your First Bot</button>
+        </div>
+    }
+    else
+    {
+        <div class="bots-grid">
+            @foreach (var bot in _bots)
+            {
+                <div class="bot-card" @onclick="() => OnEditBot(bot)">
+                    <div class="bot-icon">
+                        <img src="@GetBotAvatar(bot)" alt="@bot.Name" onerror="this.src='_content/Valour.Client/media/user-icons/icon-0.webp'" />
+                    </div>
+                    <div class="bot-info">
+                        <h4 class="bot-name">@bot.Name</h4>
+                        <p class="bot-tag">#@bot.Tag</p>
+                        <p class="bot-id">ID: @bot.Id</p>
+                    </div>
+                    <div class="bot-actions-icon">
+                        <i class="bi bi-chevron-right"></i>
+                    </div>
+                </div>
+            }
+        </div>
+    }
+</div>
 
-        <div class="bot-info-section">
-            <div class="info-item">
-                <h4>What are bots?</h4>
-                <p>Bots are automated accounts that can interact with Valour on your behalf. They can send messages, respond to commands, and integrate with external services.</p>
-            </div>
+<div class="editor-section">
+    <h3 class="editor-section-title">
+        <i class="bi bi-info-circle"></i>
+        About Bots
+    </h3>
+    <p class="subtitle">Learn how to use bots with Valour</p>
 
-            <div class="info-item">
-                <h4>How to use your bot</h4>
-                <p>Use your bot's token with the Valour SDK to authenticate. Your bot can then join planets, send messages, and respond to events.</p>
-            </div>
+    <div class="bot-info-section">
+        <div class="info-item">
+            <h4>What are bots?</h4>
+            <p>Bots are automated accounts that can interact with Valour on your behalf. They can send messages, respond to commands, and integrate with external services.</p>
+        </div>
 
-            <div class="info-item">
-                <h4>Security</h4>
-                <p>Keep your bot token secret! Anyone with access to it can control your bot. If your token is compromised, regenerate it immediately.</p>
-            </div>
+        <div class="info-item">
+            <h4>How to use your bot</h4>
+            <p>Use your bot's token with the Valour SDK to authenticate. Your bot can then join planets, send messages, and respond to events.</p>
+        </div>
+
+        <div class="info-item">
+            <h4>Security</h4>
+            <p>Keep your bot token secret! Anyone with access to it can control your bot. If your token is compromised, regenerate it immediately.</p>
         </div>
     </div>
 </div>

--- a/Valour/Client/Components/Developer/BotManagementComponent.razor.css
+++ b/Valour/Client/Components/Developer/BotManagementComponent.razor.css
@@ -1,7 +1,3 @@
-.bot-management-container {
-    padding: 1rem;
-}
-
 .bot-actions {
     margin-bottom: 2rem;
     display: flex;

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditSubscriptionsComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditSubscriptionsComponent.razor
@@ -33,9 +33,6 @@ else if (_page == SubPage.StripeResult)
 }
 else
 {
-    <h4 class="title">Subscriptions</h4>
-    <h5 class="subtitle">Support Valour and unlock perks</h5>
-
     @* Active Subscription Banner *@
     @if (_activeSub is not null)
     {


### PR DESCRIPTION
Subscriptions modal still has the old header. Now it's gone.

<details>
<summary>Before/After</summary>
<img width="1917" height="802" alt="image" src="https://github.com/user-attachments/assets/4cf8c383-fe9b-46fa-a102-f2b058d89f98" />
</details>

Bots modal had an excessive padding. No more of that, too.

<details>
<summary>Before/After</summary>
<img width="1917" height="795" alt="image" src="https://github.com/user-attachments/assets/b89866ba-beeb-405c-a34e-847b7e6de515" />
</details>