### PR TITLE
Fix tooltip positioning

### DIFF
--- a/Valour/Client/Components/Tooltips/Tooltip.razor
+++ b/Valour/Client/Components/Tooltips/Tooltip.razor
@@ -1,5 +1,6 @@
 ﻿@inherits ControlledRenderComponentBase
 @implements IDisposable
+@using System.Globalization
 @using System.Timers
 
 <div @ref="@_tooltipReference" class="tooltip @ComputedClass" style="@TooltipStyles" data-position="@Data.Trigger.Position">
@@ -18,7 +19,9 @@
     private bool _boundsCalculated = false;
 
     // Initially positioned off-screen until we calculate the proper position
-    private string TooltipStyles => _tooltipPosition is null ? "position: fixed; top: -1000px; left: -1000px; z-index: 9999;" : $"position: fixed; top: {_tooltipPosition.Value.Y}px; left: {_tooltipPosition.Value.X}px; z-index: 9999;";
+    private string TooltipStyles => _tooltipPosition is null
+        ?  "position: fixed; top: -1000px; left: -1000px; z-index: 9999;"
+        : $"position: fixed; top: {_tooltipPosition.Value.Y.ToString(CultureInfo.InvariantCulture)}px; left: {_tooltipPosition.Value.X.ToString(CultureInfo.InvariantCulture)}px; z-index: 9999;";
     private string ComputedClass => _shown ? (Data.Trigger.TooltipClass ?? "") + " show" : (Data.Trigger.TooltipClass ?? "") + " hide";
 
     private bool _shown;


### PR DESCRIPTION
Invariant culture ensures usage of period `.` instead of other delimiters commonly used by languages other than en-US. e.g. ru-RU uses a comma `,` in fractions but fractions with commas cannot be used in CSS.
<details>
<summary>Before</summary>
<img width="1750" height="907" alt="image" src="https://github.com/user-attachments/assets/e5a658ae-7f55-4c6b-872d-fd590018c766" />
</details>

<details>
<summary>After</summary>
<img width="1740" height="1093" alt="image" src="https://github.com/user-attachments/assets/5828d7fc-f01d-46e1-a35e-532ead41e35d" />
</details>