### PR TITLE
Migrate from xUnit v2 to xUnit v3

### DIFF
--- a/Valour/Tests/CustomCollectionOrderer.cs
+++ b/Valour/Tests/CustomCollectionOrderer.cs
@@ -1,29 +1,30 @@
-using Xunit.Abstractions;
+using Xunit.Sdk;
+using Xunit.v3;
 
-[assembly: TestCollectionOrderer("Valour.Tests.CustomCollectionOrderer", "Valour.Tests")]
+[assembly: TestCollectionOrderer(typeof(Valour.Tests.CustomCollectionOrderer))]
 
 namespace Valour.Tests;
 
 public class CustomCollectionOrderer : ITestCollectionOrderer
 {
-    public IEnumerable<ITestCollection> OrderTestCollections(IEnumerable<ITestCollection> testCollections)
+    public IReadOnlyCollection<TTestCollection> OrderTestCollections<TTestCollection>(IReadOnlyCollection<TTestCollection> testCollections) where TTestCollection : ITestCollection
     {
         // 1. Convert to a list for multiple passes
         var allCollections = testCollections.ToList();
 
         // 2. Extract the "last" collection(s)
         var lastCollections = allCollections
-            .Where(c => c.DisplayName.Contains("TeardownCollection"))
+            .Where(c => c.TestCollectionDisplayName.Contains("TeardownCollection"))
             .ToList();
 
         // 3. The rest of the collections (which can run in parallel)
         var otherCollections = allCollections
-            .Where(c => !c.DisplayName.Contains("TeardownCollection"))
+            .Where(c => !c.TestCollectionDisplayName.Contains("TeardownCollection"))
             .ToList();
 
         // Return "other" collections first, then last collection(s)
         // xUnit will still attempt to run them in parallel if possible,
         // but it will queue them in this order.
-        return otherCollections.Concat(lastCollections);
+        return otherCollections.Concat(lastCollections).ToList();
     }
 }

--- a/Valour/Tests/LoginTestFixture.cs
+++ b/Valour/Tests/LoginTestFixture.cs
@@ -23,7 +23,7 @@ public class LoginTestFixture : IAsyncLifetime
     public bool UserRegistered { get; private set; } = false;
     public bool UserLoggedIn { get; private set; } = false;
     
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Create the underlying WebApplicationFactory
         Factory = new WebApplicationFactory<Program>()
@@ -139,7 +139,7 @@ public class LoginTestFixture : IAsyncLifetime
         }
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         /*
         // Hard delete the test user
@@ -171,7 +171,7 @@ public class TeardownTestFixture : IAsyncLifetime
     public ValourClient Client { get; private set; } = null!;
     public RegisterUserRequest TestUserDetails { get; private set; } = null!;
     
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         // Create the underlying WebApplicationFactory
         Factory = new WebApplicationFactory<Program>()
@@ -213,7 +213,7 @@ public class TeardownTestFixture : IAsyncLifetime
         }
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         // Clean up if needed
         await Factory.DisposeAsync();

--- a/Valour/Tests/Services/AutomodServiceTests.cs
+++ b/Valour/Tests/Services/AutomodServiceTests.cs
@@ -44,7 +44,7 @@ public class AutomodServiceTests : IAsyncLifetime
         _automodService = _scope.ServiceProvider.GetRequiredService<AutomodService>();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         _owner = await _userService.GetAsync(_fixture.Client.Me.Id);
 
@@ -69,7 +69,7 @@ public class AutomodServiceTests : IAsyncLifetime
             .FirstAsync();
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         foreach (var user in _createdUsers)
         {

--- a/Valour/Tests/Services/BotServiceTests.cs
+++ b/Valour/Tests/Services/BotServiceTests.cs
@@ -34,9 +34,9 @@ public class BotServiceTests : IAsyncLifetime
         _userService = _scope.ServiceProvider.GetRequiredService<UserService>();
     }
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         foreach (var bot in _createdBots)
         {

--- a/Valour/Tests/Services/ChannelServiceTests.cs
+++ b/Valour/Tests/Services/ChannelServiceTests.cs
@@ -43,9 +43,9 @@ public class ChannelServiceTests : IAsyncLifetime
         _channelService = _scope.ServiceProvider.GetRequiredService<ChannelService>();
     }
     
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         
     }

--- a/Valour/Tests/Services/PlanetMemberServiceTests.cs
+++ b/Valour/Tests/Services/PlanetMemberServiceTests.cs
@@ -41,7 +41,7 @@ public class PlanetMemberServiceTests : IAsyncLifetime
         _userService = _scope.ServiceProvider.GetRequiredService<UserService>();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         var owner = await _userService.GetAsync(_client.Me.Id);
         var createResult = await _planetService.CreateAsync(new Planet
@@ -54,7 +54,7 @@ public class PlanetMemberServiceTests : IAsyncLifetime
         _planet = createResult.Data!;
     }
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         foreach (var memberId in _createdMembers)
         {

--- a/Valour/Tests/Services/PlanetRoleServiceTests.cs
+++ b/Valour/Tests/Services/PlanetRoleServiceTests.cs
@@ -43,7 +43,7 @@ namespace Valour.Tests.Services
         }
 
         // Clean up any created roles after all tests in this class have run
-        public async Task DisposeAsync()
+        public async ValueTask DisposeAsync()
         {
             foreach (var role in _createdRoles)
             {
@@ -57,7 +57,7 @@ namespace Valour.Tests.Services
         }
 
         // xUnit requires these to fulfill IAsyncLifetime
-        public Task InitializeAsync() => Task.CompletedTask;
+        public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
         [Fact]
         public async Task CreateRole()

--- a/Valour/Tests/Services/RegisterServiceTests.cs
+++ b/Valour/Tests/Services/RegisterServiceTests.cs
@@ -32,9 +32,9 @@ public class RegisterServiceTests : IAsyncLifetime
         _userService = _scope.ServiceProvider.GetRequiredService<UserService>();
     }
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         foreach (var user in _createdUsers)
         {

--- a/Valour/Tests/Services/UserBlockServiceTests.cs
+++ b/Valour/Tests/Services/UserBlockServiceTests.cs
@@ -26,7 +26,7 @@ public class UserBlockServiceTests : IAsyncLifetime
         _db = _scope.ServiceProvider.GetRequiredService<ValourDb>();
     }
 
-    public async Task InitializeAsync()
+    public async ValueTask InitializeAsync()
     {
         var details = await _fixture.RegisterUser();
         _secondaryUserId = await _db.Users
@@ -36,10 +36,10 @@ public class UserBlockServiceTests : IAsyncLifetime
             .FirstAsync();
     }
 
-    public Task DisposeAsync()
+    public ValueTask DisposeAsync()
     {
         _scope.Dispose();
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     [Fact]

--- a/Valour/Tests/Services/UserServiceTests.cs
+++ b/Valour/Tests/Services/UserServiceTests.cs
@@ -46,9 +46,9 @@ public class UserServiceTests : IAsyncLifetime
         _registerService = _scope.ServiceProvider.GetRequiredService<RegisterService>();
     }
 
-    public Task InitializeAsync() => Task.CompletedTask;
+    public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
-    public async Task DisposeAsync()
+    public async ValueTask DisposeAsync()
     {
         foreach (var user in _createdUsers)
         {

--- a/Valour/Tests/Valour.Tests.csproj
+++ b/Valour/Tests/Valour.Tests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <OutputType>Exe</OutputType>
         <TargetFramework>net11.0</TargetFramework>
         <EnablePreviewFeatures>True</EnablePreviewFeatures>
         <ImplicitUsings>enable</ImplicitUsings>
@@ -17,8 +18,8 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
+        <PackageReference Include="xunit.v3" Version="3.2.2" />
+        <PackageReference Include="xunit.v3.extensions.ordering" Version="0.3.0" />
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -26,7 +27,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Using Include="Xunit"/>
+        <Using Include="Xunit" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
xUnit v2 was deprecated long ago and NuGet was annoying me with vulnerable transitive dependency coming from some of the `Microsoft.NETCore` packages. Meet xUnit v3 at this point, we can still run tests from Visual Studio and now from a dedicated executable if you have desire to!
<details>
<summary>Screenshot from Visual Studio Test Explorer</summary>
<img width="1077" height="689" alt="image" src="https://github.com/user-attachments/assets/603e775e-3e37-4a3c-8f42-2d62cf248073" />
</details>
The failing tests were broken prior to migration to xUnit v3.