### PR TITLE
Fix textbox distortion on large shapes

### DIFF
--- a/Valour/Client/Components/Messages/MessageComponent.razor.css
+++ b/Valour/Client/Components/Messages/MessageComponent.razor.css
@@ -286,6 +286,11 @@
     cursor: pointer;
 }
 
+.preview-message .message {
+    max-height: 30vh;
+    overflow-y: scroll;
+}
+
 .reply .content-holder {
     padding-left: 4px;
 }

--- a/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/InputComponent.razor.css
@@ -5,7 +5,7 @@
 .textbox {
     background: var(--main-3);
     border: 1px solid var(--slight-tint);
-    border-radius: var(--radius-full);
+    border-radius: var(--radius-md);
     color: white;
     position: relative;
     margin: 10px 6px 10px 10px; /* right gap matches button gap rhythm */
@@ -26,8 +26,10 @@
     outline: none;
     width: 100%;
     height: fit-content;
+    max-height: 45vh;
     resize: none;
     vertical-align: bottom;
+    overflow-y: auto;
 }
 
 .textbox-inner {
@@ -284,4 +286,22 @@
 
 .emoji-button:hover i {
     transform: rotate(12deg) scale(1.1);
+}
+
+@media (max-width: 1280px) {
+    .textbox-wrapper {
+        max-height: 20em;
+    }
+}
+
+@media (max-width: 960px) {
+    .textbox-wrapper {
+        max-height: 15em;
+    }
+}
+
+@media (max-width: 720px) {
+    .textbox-wrapper {
+        max-height: 10em;
+    }
 }

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -721,6 +721,7 @@ app {
 
 *::-webkit-scrollbar-track {
     background: var(--main-4);
+    border-radius: var(--radius-xl);
 }
 
 *::-webkit-scrollbar-thumb {


### PR DESCRIPTION
Also tame message previews, make them smaller but scrollable. What an oversight!
<details>
<summary>Before</summary>
<img width="1917" height="1149" alt="image" src="https://github.com/user-attachments/assets/21815a36-ebf5-445c-b036-10932bb7b3fe" />
</details>
<details><summary>After</summary>
<img width="1919" height="1199" alt="image" src="https://github.com/user-attachments/assets/85255f32-d871-4dc0-8547-9e017ae21e7f" />
</details>

Comes with phone screens comfort options, like scrollable preview!
<details><summary>Example</summary>
<img width="598" height="769" alt="image" src="https://github.com/user-attachments/assets/c4dfa6ad-bc0b-4d20-99fa-3f688697f007" />
</details>