### PR TITLE
Mention+Emoji overlap Badges+UI Fix

### DIFF
--- a/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
@@ -4,7 +4,8 @@
     border-radius: var(--radius-lg);
     padding: 6px;
     background-color: var(--main-1);
-    opacity: 0.95
+    opacity: 0.95;
+    z-index: 1000l;
 }
 
 .mobile .mention-select {

--- a/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
@@ -5,7 +5,7 @@
     padding: 6px;
     background-color: var(--main-1);
     opacity: 0.95;
-    z-index: 1000l;
+    z-index: 1000;
 }
 
 .mobile .mention-select {

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -1692,6 +1692,7 @@ img.emoji {
     position: absolute;
     bottom: 50px;
     right: 0;
+    z-index: 1000;
 }
 
 /* Economy */


### PR DESCRIPTION
Fixes the fact that the @mention menu and the emoji picker overlap the badges & some UI elements

Tested on local server - working

Before:

<img width="243" height="155" alt="image" src="https://github.com/user-attachments/assets/b5989657-5068-455b-9306-8c0dedc97b3c" />

After:

<img width="225" height="155" alt="image" src="https://github.com/user-attachments/assets/a285bbfc-bbdf-4b47-ab4b-12858fc80adc" />
