### PR TITLE
Fix channel visibility leaking to members without view access

### DIFF
--- a/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
@@ -147,6 +147,7 @@
         Channel.MessageReceived += OnReceiveMessage;
         Channel.MessageEdited += OnReceiveMessageEdit;
         Channel.MessageDeleted += OnDeleteMessage;
+        Channel.Deleted += OnChannelDeleted;
 
         if (WindowCtx?.Tab is not null)
             WindowCtx.Tab.OnStartFloating += OnStartFloating;
@@ -497,6 +498,18 @@
             return Task.CompletedTask;
 
         return WindowCtx.Tab.SetContent(HomeWindowComponent.DefaultContent);
+    }
+
+    public Task OnChannelDeleted()
+    {
+        if (WindowCtx?.Tab is null)
+            return Task.CompletedTask;
+
+        var content = Channel?.PlanetId is not null
+            ? ThreadsWindowComponent.GetDefaultContent(Channel.Planet)
+            : ThreadsWindowComponent.DefaultContent;
+
+        return WindowCtx.Tab.SetContent(content);
     }
     
     public async Task<List<PlanetMember>> GetLastChatMembers(int count)
@@ -1532,6 +1545,7 @@
         Channel.MessageDeleted -= OnDeleteMessage;
         Channel.MessageReceived -= OnReceiveMessage;
         Channel.MessageEdited -= OnReceiveMessageEdit;
+        Channel.Deleted -= OnChannelDeleted;
 
         if (WindowCtx?.Tab is not null)
             WindowCtx.Tab.OnStartFloating -= OnStartFloating;

--- a/Valour/Server/Hubs/SignalRConnectionService.cs
+++ b/Valour/Server/Hubs/SignalRConnectionService.cs
@@ -187,12 +187,24 @@ public class SignalRConnectionService : IDisposable
     /// <summary>
     /// Removes group membership tracking for a connection
     /// </summary>
-    public async Task UntrackGroupMembershipAsync(string groupId, HubCallerContext context)
+    public Task UntrackGroupMembershipAsync(string groupId, HubCallerContext context)
     {
-        if (string.IsNullOrEmpty(groupId) || context == null)
+        if (context == null)
+            return Task.CompletedTask;
+
+        return UntrackGroupMembershipAsync(groupId, context.ConnectionId);
+    }
+
+    /// <summary>
+    /// Removes group membership tracking for a connection, identified directly by connection id.
+    /// Used to evict a connection from outside the hub itself, where no HubCallerContext exists
+    /// (e.g. when a permission change revokes a member's access to a channel they're already viewing).
+    /// </summary>
+    public async Task UntrackGroupMembershipAsync(string groupId, string connectionId)
+    {
+        if (string.IsNullOrEmpty(groupId) || string.IsNullOrEmpty(connectionId))
             return;
 
-        var connectionId = context.ConnectionId;
         long? userId = null;
         
         // Get the user ID from the connection identity

--- a/Valour/Server/Services/ChannelService.cs
+++ b/Valour/Server/Services/ChannelService.cs
@@ -289,6 +289,14 @@ public class ChannelService
                 channelsToDelete.Add(associated);
         }
 
+        // Capture who could view these channels before they're removed from the
+        // hosted planet/permission cache, since access can no longer be computed afterward.
+        var viewersByChannelId = new Dictionary<long, List<long>>();
+        foreach (var channelToDelete in channelsToDelete)
+        {
+            viewersByChannelId[channelToDelete.Id] = await _planetPermissionService.GetChannelViewerUserIdsAsync(hostedPlanet, channelToDelete.Id);
+        }
+
         foreach (var channelToDelete in channelsToDelete)
         {
             channelToDelete.IsDeleted = true;
@@ -309,9 +317,9 @@ public class ChannelService
         {
             var model = channelToDelete.ToModel();
             if (model.PlanetId is not null)
-                _coreHub.NotifyPlanetItemDelete(model.PlanetId.Value, model);
+                _coreHub.NotifyChannelDelete(model, viewersByChannelId[channelToDelete.Id]);
         }
-        
+
         return TaskResult.SuccessResult;
     }
     
@@ -445,10 +453,18 @@ public class ChannelService
             if (associatedChatChannel is not null)
             {
                 hostedPlanet.UpsertChannel(associatedChatChannel);
-                _coreHub.NotifyPlanetItemChange(channel.PlanetId!.Value, associatedChatChannel);
             }
+
             await _planetPermissionService.HandleChannelTopologyChange(channel.PlanetId!.Value);
-            _coreHub.NotifyPlanetItemChange(channel.PlanetId!.Value, channel);
+
+            if (associatedChatChannel is not null)
+            {
+                var chatViewers = await _planetPermissionService.GetChannelViewerUserIdsAsync(hostedPlanet, associatedChatChannel.Id);
+                _coreHub.NotifyChannelChange(associatedChatChannel, chatViewers);
+            }
+
+            var viewers = await _planetPermissionService.GetChannelViewerUserIdsAsync(hostedPlanet, channel.Id);
+            _coreHub.NotifyChannelChange(channel, viewers);
         }
 
         return TaskResult<Channel>.FromData(channel);
@@ -519,7 +535,9 @@ public class ChannelService
         {
             hostedPlanet.UpsertChannel(updated);
             await _planetPermissionService.HandleChannelTopologyChange(updated.PlanetId!.Value);
-            _coreHub.NotifyPlanetItemChange(updated.PlanetId!.Value, updated);
+
+            var viewers = await _planetPermissionService.GetChannelViewerUserIdsAsync(hostedPlanet, updated.Id);
+            _coreHub.NotifyChannelChange(updated, viewers);
         }
 
         // Response

--- a/Valour/Server/Services/CoreHubService.cs
+++ b/Valour/Server/Services/CoreHubService.cs
@@ -225,6 +225,52 @@ public class CoreHubService
     public void NotifyPlanetItemDelete<T>(long planetId, T model) =>
         _ = _hub.Clients.Group($"p-{planetId}").SendAsync($"{typeof(T).Name}-Delete", model);
 
+    public void NotifyChannelChange(Channel channel, IReadOnlyCollection<long> recipientUserIds, int flags = 0)
+    {
+        if (recipientUserIds.Count == 0)
+            return;
+
+        var groups = recipientUserIds.Select(id => $"u-{id}").ToArray();
+        _ = _hub.Clients.Groups(groups).SendAsync($"{nameof(Channel)}-Update", channel, flags);
+    }
+
+    public void NotifyChannelDelete(Channel channel, IReadOnlyCollection<long> recipientUserIds)
+    {
+        if (recipientUserIds.Count == 0)
+            return;
+
+        var groups = recipientUserIds.Select(id => $"u-{id}").ToArray();
+        _ = _hub.Clients.Groups(groups).SendAsync($"{nameof(Channel)}-Delete", channel);
+    }
+
+    /// <summary>
+    /// Removes any currently-connected clients belonging to the given users from a channel's
+    /// real-time message group, so they stop receiving live messages for a channel they've just
+    /// lost view access to. A permission change doesn't otherwise affect an already-joined group.
+    /// </summary>
+    public async Task EvictUsersFromChannelGroupAsync(long channelId, IReadOnlyCollection<long> userIds)
+    {
+        if (userIds.Count == 0)
+            return;
+
+        var groupId = $"c-{channelId}";
+        var connections = _connectionTracker.GetGroupConnections(groupId);
+        if (connections.Length == 0)
+            return;
+
+        var userIdSet = userIds.ToHashSet();
+
+        foreach (var connectionId in connections)
+        {
+            var token = _connectionTracker.GetToken(connectionId);
+            if (token is null || !userIdSet.Contains(token.UserId))
+                continue;
+
+            await _hub.Groups.RemoveFromGroupAsync(connectionId, groupId);
+            await _connectionTracker.UntrackGroupMembershipAsync(groupId, connectionId);
+        }
+    }
+
     public void NotifyPlanetChange(Planet item, int flags = 0) =>
         _ = _hub.Clients.Group($"p-{item.Id}").SendAsync($"{nameof(Planet)}-Update", item, flags);
 

--- a/Valour/Server/Services/PermissionsNodeService.cs
+++ b/Valour/Server/Services/PermissionsNodeService.cs
@@ -1,4 +1,4 @@
-﻿using Valour.Server.Database;
+using Valour.Server.Database;
 using Valour.Shared;
 using Valour.Shared.Models;
 
@@ -10,17 +10,69 @@ public class PermissionsNodeService
     private readonly CoreHubService _coreHub;
     private readonly ILogger<PermissionsNodeService> _logger;
     private readonly PlanetPermissionService _permissionService;
+    private readonly HostedPlanetService _hostedPlanetService;
 
     public PermissionsNodeService(
         ValourDb db,
         CoreHubService coreHub,
-        ILogger<PermissionsNodeService> logger, 
-        PlanetPermissionService permissionService)
+        ILogger<PermissionsNodeService> logger,
+        PlanetPermissionService permissionService,
+        HostedPlanetService hostedPlanetService)
     {
         _db = db;
         _coreHub = coreHub;
         _logger = logger;
         _permissionService = permissionService;
+        _hostedPlanetService = hostedPlanetService;
+    }
+
+    /// <summary>
+    /// Returns the user ids of planet members who can currently view the channels affected by
+    /// a node targeting the given channel id (the channel itself, plus anything inheriting its
+    /// permissions). Used to snapshot access before a node changes, so the after-state can be
+    /// diffed to find members who lost access.
+    /// </summary>
+    private async Task<Dictionary<long, List<long>>> SnapshotAffectedChannelViewersAsync(
+        HostedPlanet hostedPlanet,
+        long targetChannelId)
+    {
+        var affectedChannelIds = new List<long> { targetChannelId };
+        var inheritors = hostedPlanet.GetInheritors(targetChannelId);
+        if (inheritors is not null)
+            affectedChannelIds.AddRange(inheritors);
+
+        var snapshot = new Dictionary<long, List<long>>(affectedChannelIds.Count);
+        foreach (var channelId in affectedChannelIds)
+        {
+            snapshot[channelId] = await _permissionService.GetChannelViewerUserIdsAsync(hostedPlanet, channelId);
+        }
+
+        return snapshot;
+    }
+
+    /// <summary>
+    /// Diffs the given pre-change viewer snapshot against current access and, for any member who
+    /// lost view access to a channel, evicts their already-joined connections from that channel's
+    /// real-time message group and tells their client the channel is gone. Permission changes don't
+    /// otherwise affect an already-joined SignalR group, so without this a member who revokes a
+    /// role's view of a channel would keep receiving live messages for it.
+    /// </summary>
+    private async Task RevokeLostChannelAccessAsync(HostedPlanet hostedPlanet, Dictionary<long, List<long>> beforeViewers)
+    {
+        foreach (var (channelId, before) in beforeViewers)
+        {
+            var channel = hostedPlanet.GetChannel(channelId);
+            if (channel is null)
+                continue;
+
+            var after = await _permissionService.GetChannelViewerUserIdsAsync(hostedPlanet, channelId);
+            var revoked = before.Except(after).ToList();
+            if (revoked.Count == 0)
+                continue;
+
+            await _coreHub.EvictUsersFromChannelGroupAsync(channelId, revoked);
+            _coreHub.NotifyChannelDelete(channel, revoked);
+        }
     }
 
     /// <summary>
@@ -31,18 +83,21 @@ public class PermissionsNodeService
 
     public async Task<PermissionsNode> GetAsync(long? targetId, long roleId, ChannelTypeEnum type) =>
         (await _db.PermissionsNodes.FirstOrDefaultAsync(x => x.TargetId == targetId && x.RoleId == roleId && x.TargetType == type)).ToModel();
-    
+
     public async Task<List<PermissionsNode>> GetAllAsync(long planetId) =>
         (await _db.PermissionsNodes.Where(x => x.PlanetId == planetId).Select(x => x.ToModel()).ToListAsync());
 
     public async Task<TaskResult<PermissionsNode>> PutAsync(PermissionsNode newNode)
     {
+        var hostedPlanet = await _hostedPlanetService.GetRequiredAsync(newNode.PlanetId);
+        var beforeViewers = await SnapshotAffectedChannelViewersAsync(hostedPlanet, newNode.TargetId);
+
         await using var trans = await _db.Database.BeginTransactionAsync();
-        
+
         try
         {
             var oldNode = await _db.PermissionsNodes.FindAsync(newNode.Id);
-            
+
             if (oldNode is null) return new(false, $"PermissionNode not found");
             _db.Entry(oldNode).CurrentValues.SetValues(newNode);
             await _db.SaveChangesAsync();
@@ -56,18 +111,23 @@ public class PermissionsNodeService
             _logger.LogError("Error updating permissions node in DB: {Error}", e.Message);
             return new(false, e.Message);
         }
-        
+
         // Update permissions
         await _permissionService.HandleNodeChange(newNode);
+
+        await RevokeLostChannelAccessAsync(hostedPlanet, beforeViewers);
 
         _coreHub.NotifyPlanetItemChange(newNode);
 
         return new(true, "Success", newNode);
     }
-    
+
     public async Task<TaskResult<PermissionsNode>> CreateAsync(PermissionsNode node)
     {
         node.Id = IdManager.Generate();
+
+        var hostedPlanet = await _hostedPlanetService.GetRequiredAsync(node.PlanetId);
+        var beforeViewers = await SnapshotAffectedChannelViewersAsync(hostedPlanet, node.TargetId);
 
         try
         {
@@ -79,9 +139,11 @@ public class PermissionsNodeService
             _logger.LogError("Error saving permissions node to DB: {Error}", e.Message);
             return new(false, e.Message);
         }
-        
+
         // Update permissions
         await _permissionService.HandleNodeChange(node);
+
+        await RevokeLostChannelAccessAsync(hostedPlanet, beforeViewers);
 
         _coreHub.NotifyPlanetItemChange(node);
 

--- a/Valour/Server/Services/PlanetPermissionService.cs
+++ b/Valour/Server/Services/PlanetPermissionService.cs
@@ -212,6 +212,50 @@ public class PlanetPermissionService
         return access != null && access.Contains(channelId);
     }
 
+    /// <summary>
+    /// Returns the user ids of planet members who can currently view the given channel.
+    /// Used to scope real-time channel events (create/update/delete/access-revoked) so they
+    /// don't leak the channel's existence to members without view access.
+    /// </summary>
+    public async Task<List<long>> GetChannelViewerUserIdsAsync(HostedPlanet hostedPlanet, long channelId)
+    {
+        var members = await _db.PlanetMembers
+            .AsNoTracking()
+            .Where(x => x.PlanetId == hostedPlanet.Planet.Id)
+            .Select(x => new { x.Id, x.UserId, x.RoleMembership })
+            .ToArrayAsync();
+
+        var accessByRoleMembership = new Dictionary<PlanetRoleMembership, bool>();
+        var viewerUserIds = new List<long>(members.Length);
+
+        foreach (var member in members)
+        {
+            bool hasAccess;
+
+            // Owners bypass role-based access, so they can't share the role-combo cache.
+            if (member.UserId == hostedPlanet.Planet.OwnerId)
+            {
+                hasAccess = await HasChannelAccessAsync(member.Id, channelId);
+            }
+            else if (!accessByRoleMembership.TryGetValue(member.RoleMembership, out hasAccess))
+            {
+                hasAccess = await HasChannelAccessAsync(member.Id, channelId);
+                accessByRoleMembership[member.RoleMembership] = hasAccess;
+            }
+
+            if (hasAccess)
+                viewerUserIds.Add(member.UserId);
+        }
+
+        return viewerUserIds;
+    }
+
+    public async Task<List<long>> GetChannelViewerUserIdsAsync(long planetId, long channelId)
+    {
+        var hostedPlanet = await _hostedPlanetService.GetRequiredAsync(planetId);
+        return await GetChannelViewerUserIdsAsync(hostedPlanet, channelId);
+    }
+
     public async ValueTask<uint> GetAuthorityAsync(PlanetMember member)
     {
         var hostedPlanet = await _hostedPlanetService.GetRequiredAsync(member.PlanetId);


### PR DESCRIPTION
Channel create/update/delete events were broadcast to the whole planet
instead of just members with View access, so new/edited "private"
channels showed up for everyone in real time (#1571).

- Scope channel create/update/delete real-time events to actual viewers
  instead of the whole planet group
- When a permission node revokes a member's view access to a channel,
  evict their live connection from that channel's message group and
  tell their client the channel is gone instead of leaving it stale
- Chat tabs now redirect to Threads when their channel disappears
  (covers both real deletion and access revocation)
  
  
Video of it working:
https://github.com/user-attachments/assets/4a6dd2aa-af43-4317-9a36-848459db24f3

