### PR TITLE
Fix stale permission cache after granting/removing a role

### DIFF
--- a/Valour/Server/Services/PlanetMemberService.cs
+++ b/Valour/Server/Services/PlanetMemberService.cs
@@ -481,7 +481,12 @@ public class PlanetMemberService
         // Fetch updated member for notification
         var member = await _db.PlanetMembers.FindAsync(memberId);
         if (member is not null)
+        {
+            // The member's new role combo may collide with another member's already-cached
+            // combo, which would otherwise keep serving stale access/permissions for it.
+            hostedPlanet.PermissionCache.ClearCacheForCombo(member.RoleMembership);
             _coreHub.NotifyPlanetItemChange(member.ToModel());
+        }
 
         return new TaskResult(true, "Success");
     }
@@ -537,7 +542,12 @@ public class PlanetMemberService
         // Fetch updated member for notification
         var member = await _db.PlanetMembers.FindAsync(memberId);
         if (member is not null)
+        {
+            // The member's new role combo may collide with another member's already-cached
+            // combo, which would otherwise keep serving stale access/permissions for it.
+            hostedPlanet.PermissionCache.ClearCacheForCombo(member.RoleMembership);
             _coreHub.NotifyPlanetItemChange(member.ToModel());
+        }
 
         return TaskResult.SuccessResult;
     }


### PR DESCRIPTION
AddRoleAsync/RemoveRoleAsync updated a member's role bits in the database but never invalidated the channel-access/permission cache, which is keyed by the role-combo bitmask rather than the member.

If that exact combo had ever been cached before (e.g. from another member, or from an earlier state), the grant/removal kept serving the old cached access instead of recalculating it - visible as a role showing correctly everywhere except actual channel access, only "fixing itself" when some unrelated action happened to clear that cache entry.

Clear the cache for the member's new role combo right after the database write so access is recalculated fresh.

Should probably be implemented if #1577 is implemented as it fixes a big issue with permissions when accessing channels.