### PR TITLE
Fix OAuth authorize endpoint returning invalid JSON

### DIFF
--- a/Valour/Server/Api/Dynamic/OauthAppApi.cs
+++ b/Valour/Server/Api/Dynamic/OauthAppApi.cs
@@ -212,7 +212,7 @@ public class OauthAppApi
 
         context.Response.Headers.Add("Access-Control-Allow-Origin", "*");
 
-        return ValourResult.Ok($"{model.RedirectUri}?code={model.Code}&state={model.State}&node={NodeConfig.Instance.Name}");
+        return ValourResult.Json($"{model.RedirectUri}?code={model.Code}&state={model.State}&node={NodeConfig.Instance.Name}");
     }
 
     [ValourRoute(HttpVerbs.Post, "api/oauth/token")]


### PR DESCRIPTION
## Summary
`AuthorizeAsync` returned the redirect URL via `ValourResult.Ok(...)` (raw unquoted text), but the client always deserializes responses as JSON — so the call silently failed despite a `200 OK`, breaking the OAuth flow. Switched to `ValourResult.Json(...)` so the string is properly quoted/parseable.

## Why this is safe
Change is scoped to one return statement. The only two callers already expected a JSON string response — they were broken by the old behavior, not relying on it.
