### PR TITLE
Fix mention list and emoji picker rendering behind other UI

### DIFF
--- a/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
+++ b/Valour/Client/Components/Windows/ChannelWindows/MentionSelectComponent.razor.css
@@ -4,6 +4,7 @@
     border-radius: var(--radius-lg);
     padding: 6px;
     background-color: var(--main-1);
+    z-index: 1000;
     opacity: 0.95
 }
 

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -1692,6 +1692,7 @@ img.emoji {
     position: absolute;
     bottom: 50px;
     right: 0;
+    z-index: 1000;
 }
 
 /* Economy */


### PR DESCRIPTION
## Summary
The mention select dropdown and emoji picker had no `z-index`, so they could render behind other overlapping UI elements. Added `z-index: 1000` to both so they always display on top.

## Why this is safe
Purely a stacking-order fix — no layout, markup, or behavior changes.
