### PR TITLE
Add show/hide toggle to password fields

### DIFF
--- a/Valour/Client/Components/Menus/Modals/ChangePasswordModal.razor
+++ b/Valour/Client/Components/Menus/Modals/ChangePasswordModal.razor
@@ -5,11 +5,11 @@
     <MainArea>
         <div class="form-group">
             <label class="m-2">Password</label>
-            <input id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password" />
+            <PasswordInput id="password-input" autocomplete="current-password" @bind-Value="@_password" />
             <label class="m-2">New Password</label>
-            <input id="new-password-input" type="password" autocomplete="new-password" class="form-control" @bind-value="@_newPassword" />
+            <PasswordInput id="new-password-input" autocomplete="new-password" @bind-Value="@_newPassword" />
             <label class="m-2">Confirm New Password</label>
-            <input id="new-password-confirm-input" type="password" autocomplete="new-password" class="form-control" @bind-value="@_newPasswordConfirm" />
+            <PasswordInput id="new-password-confirm-input" autocomplete="new-password" @bind-Value="@_newPasswordConfirm" />
         </div>
 
         <ResultLabel Result="@_result" />

--- a/Valour/Client/Components/Menus/Modals/ChangeUsernameModal.razor
+++ b/Valour/Client/Components/Menus/Modals/ChangeUsernameModal.razor
@@ -6,10 +6,10 @@
         @if (_canChangeUsername)
         {
             <div class="form-group">
-                <label class="m-2">Password</label>
-                <input id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password"/>
                 <label class="m-2">New Username</label>
                 <input id="new-username-input" type="text" autocomplete="off" class="form-control" @bind-value="@_newUsername"/>
+                <label class="m-2">Password</label>
+                <PasswordInput id="password-input" autocomplete="current-password" @bind-Value="@_password"/>
             </div>
         }
         else

--- a/Valour/Client/Components/Menus/Modals/DeleteAccountModal.razor
+++ b/Valour/Client/Components/Menus/Modals/DeleteAccountModal.razor
@@ -8,7 +8,7 @@
         
         <div class="form-group">
             <label>Password</label>
-            <input id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password" />
+            <PasswordInput id="password-input" autocomplete="current-password" @bind-Value="@_password" />
         </div>
         
         @if (!string.IsNullOrWhiteSpace(_errorSpan))

--- a/Valour/Client/Components/Utility/LoginComponent.razor
+++ b/Valour/Client/Components/Utility/LoginComponent.razor
@@ -36,7 +36,7 @@
             </div>
             <div class="form-group mt-2">
                 <label>Password</label>
-                <input @ref="@PasswordInput" id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password" @onkeyup="@OnPasswordKey"/>
+                <PasswordInput @ref="@PasswordInput" id="password-input" autocomplete="current-password" @bind-Value="@_password" OnKeyUp="@OnPasswordKey"/>
                 <span id="password-span" class="text-danger">@_passwordSpan</span>
             </div>
             <span id="result-span" class="text-info">@_resultSpan</span>
@@ -82,7 +82,7 @@
 
 @code {
     
-    private ElementReference PasswordInput { get; set; }
+    private PasswordInput PasswordInput { get; set; }
     
     [Parameter]
     public bool FromVerified { get; set; }

--- a/Valour/Client/Components/Utility/PasswordConfirmModal.razor
+++ b/Valour/Client/Components/Utility/PasswordConfirmModal.razor
@@ -4,7 +4,7 @@
     <MainArea>
         <p>@Data.Description</p>
         <div class="form-group">
-            <input placeholder="Enter Password..." id="password-input" type="password" autocomplete="current-password" class="form-control" @bind-value="@_password"/>
+            <PasswordInput placeholder="Enter Password..." id="password-input" autocomplete="current-password" @bind-Value="@_password"/>
             <ResultLabel Style="margin-top: 1em" Result="@_result" />
         </div>
     </MainArea>

--- a/Valour/Client/Components/Utility/PasswordInput.razor
+++ b/Valour/Client/Components/Utility/PasswordInput.razor
@@ -1,0 +1,49 @@
+@* Password input with a show/hide toggle. Forwards unmatched attributes (id, autocomplete, placeholder, disabled, etc) to the underlying input. *@
+
+<div class="password-input-wrapper">
+    <input @ref="_inputRef"
+           type="@(_visible ? "text" : "password")"
+           class="form-control"
+           value="@Value"
+           @oninput="OnInput"
+           @onkeyup="OnKeyUp"
+           @attributes="AdditionalAttributes" />
+    <button type="button"
+            class="password-input-toggle"
+            tabindex="-1"
+            @onclick="ToggleVisibility"
+            title="@(_visible ? "Hide password" : "Show password")"
+            aria-label="@(_visible ? "Hide password" : "Show password")">
+        <i class="bi @(_visible ? "bi-eye-slash-fill" : "bi-eye-fill")" aria-hidden="true"></i>
+    </button>
+</div>
+
+@code {
+    [Parameter]
+    public string Value { get; set; }
+
+    [Parameter]
+    public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter]
+    public EventCallback<KeyboardEventArgs> OnKeyUp { get; set; }
+
+    [Parameter(CaptureUnmatchedValues = true)]
+    public Dictionary<string, object> AdditionalAttributes { get; set; }
+
+    private ElementReference _inputRef;
+    private bool _visible;
+
+    public ValueTask FocusAsync() => _inputRef.FocusAsync();
+
+    private async Task OnInput(ChangeEventArgs e)
+    {
+        Value = e.Value?.ToString();
+        await ValueChanged.InvokeAsync(Value);
+    }
+
+    private void ToggleVisibility()
+    {
+        _visible = !_visible;
+    }
+}

--- a/Valour/Client/Pages/RecoverPassword.razor
+++ b/Valour/Client/Pages/RecoverPassword.razor
@@ -21,12 +21,12 @@
                     <div asp-validation-summary="All" class="text-danger"></div>
                     <div class="form-group mt-2">
                         <label>New Password</label>
-                        <input type="password" class="form-control" @bind-value="@password"/>
+                        <PasswordInput autocomplete="new-password" @bind-Value="@password"/>
                         <span id="password-span" class="text-danger">@passwordSpan</span>
                     </div>
                     <div class="form-group mt-2">
                         <label>Confirm Password</label>
-                        <input type="password" class="form-control" @bind-value="@passwordConf"/>
+                        <PasswordInput autocomplete="new-password" @bind-Value="@passwordConf"/>
                         <span id="password-conf-span" class="text-danger">@passwordConfSpan</span>
                     </div>
                     <span id="result-span" class="text-info">@resultSpan</span>

--- a/Valour/Client/Pages/Register.razor
+++ b/Valour/Client/Pages/Register.razor
@@ -27,11 +27,11 @@
                     </div>
                     <div class="form-group mt-2">
                         <label>Password</label>
-                        <input type="password" class="form-control" @bind-value="@_password" />
+                        <PasswordInput autocomplete="new-password" @bind-Value="@_password" />
                     </div>
                     <div class="form-group mt-2">
                         <label>Confirm Password</label>
-                        <input type="password" class="form-control" @bind-value="@_passwordConf" />
+                        <PasswordInput autocomplete="new-password" @bind-Value="@_passwordConf" />
                     </div>
                     <div class="form-group mt-2">
                         <label>Birthday</label>

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -508,6 +508,34 @@ label {
     cursor: not-allowed;
 }
 
+.password-input-wrapper {
+    position: relative;
+    display: flex;
+}
+
+.password-input-wrapper .form-control {
+    padding-right: 2.5rem;
+}
+
+.password-input-toggle {
+    position: absolute;
+    top: 50%;
+    right: 0.75rem;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    padding: 0;
+    color: var(--font-alt-color);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    font-size: var(--font-size-md);
+}
+
+.password-input-toggle:hover {
+    color: var(--font-color);
+}
+
 .form-select {
     background-color: var(--main-3);
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23fff' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3e%3c/svg%3e");


### PR DESCRIPTION
## Summary
- Adds a `PasswordInput.razor` component with a clickable eye icon (`bi-eye-fill` / `bi-eye-slash-fill`) that toggles the field between `type="password"` and `type="text"`, so users can verify what they've typed before submitting.
- Swaps every plain `<input type="password">` in the app over to the new component: Login, Register, Recover Password, Change Password, Change Username, Delete Account, and the generic Password-Confirm modal.
- Adds the supporting CSS (`.password-input-wrapper`, `.password-input-toggle`) to `globals.css` to position the icon inside the field.

## Test plan
- [x] `dotnet build` — 0 errors
- [x] Verified working in a dev session