### PR TITLE
Add "Big Emojis" preference: render emoji-only messages at heading size

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditDevicePreferencesComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditDevicePreferencesComponent.razor
@@ -24,6 +24,17 @@
 
         <div class="toggle-item">
             <div class="toggle-header">
+                <span class="toggle-title">Big Emojis</span>
+                <label class="switch">
+                    <input type="checkbox" @onclick="SwitchBigEmojiMessages" checked="@DevicePreferences.BigEmojiMessages">
+                    <span class="slider round"></span>
+                </label>
+            </div>
+            <p class="toggle-description">When enabled, messages containing only a few emojis (5 or less) are shown larger.</p>
+        </div>
+
+        <div class="toggle-item">
+            <div class="toggle-header">
                 <span class="toggle-title">Error Reporting</span>
                 <label class="switch">
                     <input type="checkbox" @onclick="OnErrorReportingClick" checked="@_errorReportingEnabled">
@@ -396,6 +407,11 @@
         DevicePreferences.AutoEmoji = !DevicePreferences.AutoEmoji;
         await LocalStorage.SetAsync("AutoEmoji", DevicePreferences.AutoEmoji);
         MarkdownManager.RegenPipeline();
+    }
+
+    private async Task SwitchBigEmojiMessages()
+    {
+        await DevicePreferences.SetBigEmojiMessages(!DevicePreferences.BigEmojiMessages, LocalStorage);
     }
 
     private string GetMicPermissionDescription()

--- a/Valour/Client/Components/Messages/MessageComponent.razor
+++ b/Valour/Client/Components/Messages/MessageComponent.razor
@@ -201,8 +201,10 @@ else
         if (string.IsNullOrWhiteSpace(_message.Content))
             return;
         
+        var isBigEmoji = DevicePreferences.BigEmojiMessages && MarkdownManager.IsEmojiOnlyMessage(_message.Content);
+
         builder.OpenElement(0, "div");
-        builder.AddAttribute(1, "class", "fragments");
+        builder.AddAttribute(1, "class", isBigEmoji ? "fragments big-emoji" : "fragments");
         try
         {
             Markdown.RenderToFragment(

--- a/Valour/Client/Device/DevicePreferences.cs
+++ b/Valour/Client/Device/DevicePreferences.cs
@@ -17,6 +17,12 @@ public static class DevicePreferences
     /// </summary>
     public static bool AutoEmoji { get; set; } = false; // Default it to off
 
+    /// <summary>
+    /// True if messages containing only a few emojis (and no other text) should
+    /// be rendered larger, the same size as a heading.
+    /// </summary>
+    public static bool BigEmojiMessages { get; set; } = true;
+
     public static string? MicrophoneDeviceId { get; set; }
     public static string? CameraDeviceId { get; set; }
     public static bool ErrorReportingEnabled { get; private set; }
@@ -46,11 +52,22 @@ public static class DevicePreferences
         await localStorage.SetAsync(ErrorReportingEnabledStorageKey, isEnabled);
     }
 
+    public static async Task SetBigEmojiMessages(bool isEnabled, IAppStorage localStorage)
+    {
+        BigEmojiMessages = isEnabled;
+        await localStorage.SetAsync("BigEmojiMessages", isEnabled);
+    }
+
     public static async Task LoadPreferences(IAppStorage localStorage)
     {
         if (await localStorage.ContainsKeyAsync("AutoEmoji"))
         {
             AutoEmoji = await localStorage.GetAsync<bool>("AutoEmoji");
+        }
+
+        if (await localStorage.ContainsKeyAsync("BigEmojiMessages"))
+        {
+            BigEmojiMessages = await localStorage.GetAsync<bool>("BigEmojiMessages");
         }
 
         if (await localStorage.ContainsKeyAsync("MicrophoneDeviceId"))

--- a/Valour/Client/Messages/Rendering/MarkdownManager.cs
+++ b/Valour/Client/Messages/Rendering/MarkdownManager.cs
@@ -1,6 +1,8 @@
 ﻿using Markdig;
 using Markdig.Blazor;
 using Markdig.Extensions.AutoLinks;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
 using Valour.Client.Device;
 using Valour.Client.Markdig;
 using Markdown = Markdig.Markdown;
@@ -49,6 +51,57 @@ public static class MarkdownManager
         // Must be inserted ahead of the package's built-in LinkInlineRenderer so
         // Valour links get in-app navigation instead of opening a new tab.
         Renderer.ObjectRenderers.Insert(0, new ValourLinkRenderer());
+    }
+
+    /// <summary>
+    /// Maximum number of emojis a message can contain and still be rendered
+    /// large by the "big emoji" preference.
+    /// </summary>
+    public const int MaxBigEmojiCount = 5;
+
+    /// <summary>
+    /// Returns true if the given message content is made up of nothing but
+    /// 1-5 emojis (no other text), and is therefore eligible to be rendered
+    /// at heading size when the big-emoji preference is enabled.
+    /// </summary>
+    public static bool IsEmojiOnlyMessage(string content)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return false;
+
+        MarkdownDocument document;
+
+        try
+        {
+            document = Markdown.Parse(content, Pipeline);
+        }
+        catch
+        {
+            return false;
+        }
+
+        if (document.Count != 1 || document[0] is not ParagraphBlock { Inline: { } inline })
+            return false;
+
+        var emojiCount = 0;
+
+        foreach (var item in inline)
+        {
+            switch (item)
+            {
+                case ValourEmojiInline:
+                    emojiCount++;
+                    break;
+                case LineBreakInline:
+                    break;
+                case LiteralInline literal when literal.Content.IsEmptyOrWhitespace():
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return emojiCount is > 0 and <= MaxBigEmojiCount;
     }
 
     public static string GetHtml(string content)

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -1169,6 +1169,10 @@ img.emoji {
     max-height: 900px !important;
 }
 
+.message .fragments.big-emoji {
+    font-size: var(--font-size-5xl);
+}
+
 .message .fragments a:not(.nohide) {
     font-size: 0;
 }


### PR DESCRIPTION
## Summary
Adds an opt-in "Big Emojis" toggle in Device Preferences. When enabled, messages containing only 1–5 emojis (no other text) render at the same larger size as a `#` heading.
