### PR TITLE
Feat/security page revamp

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor
@@ -200,6 +200,10 @@
                     <img src="../_content/Valour.Client/media/logo/logo-64.png" alt="OAuth App" class="app-icon" />
                     <span class="app-name">OAuth App (@token.AppId)</span>
                 }
+                @if (token.IsCurrent)
+                {
+                    <span class="badge badge-primary">Current Session</span>
+                }
             </div>
             <div class="token-actions">
                 @if (!IsExpired(token))
@@ -224,12 +228,6 @@
                     }
                 </span>
             </div>
-            @if (token.IsCurrent)
-            {
-                <div class="current-session">
-                    <span class="badge badge-primary">Current Session</span>
-                </div>
-            }
         </div>
     </div>;
 

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor
@@ -96,61 +96,9 @@
     else
     {
         <div class="tokens-list">
-            @foreach (var token in Tokens)
+            @foreach (var token in _activeTokens)
             {
-                var isExpired = IsExpired(token);
-                var expiresSoon = ExpiresSoon(token);
-
-                <div class="token-item @(isExpired ? "expired" : expiresSoon ? "expires-soon" : "")">
-                    <div class="token-header">
-                        <div class="token-app">
-                            @if (token.AppId == "VALOUR")
-                            {
-                                <img src="../_content/Valour.Client/media/logo/logo-64.png" alt="Valour" class="app-icon" />
-                                <span class="app-name">Valour Web Client</span>
-                            }
-                            else if (_appInfoCache.TryGetValue(token.AppId, out var appInfo))
-                            {
-                                <img src="@appInfo.ImageUrl" alt="@appInfo.Name" class="app-icon" />
-                                <span class="app-name">@appInfo.Name</span>
-                            }
-                            else
-                            {
-                                <img src="../_content/Valour.Client/media/logo/logo-64.png" alt="OAuth App" class="app-icon" />
-                                <span class="app-name">OAuth App (@token.AppId)</span>
-                            }
-                        </div>
-                        <div class="token-actions">
-                            @if (!isExpired)
-                            {
-                                <VButton Variant="danger" Size="sm" OnClick="@(() => RevokeToken(token))">Revoke</VButton>
-                            }
-                        </div>
-                    </div>
-
-                    <div class="token-details">
-                        <div class="token-info">
-                            <span class="label">Created:</span>
-                            <span>@token.TimeCreated.ToString("MMM dd, yyyy 'at' HH:mm UTC")</span>
-                        </div>
-                        <div class="token-info">
-                            <span class="label">Expires:</span>
-                            <span class="@(isExpired ? "expired" : expiresSoon ? "expires-soon" : "")">
-                                @token.TimeExpires.ToString("MMM dd, yyyy 'at' HH:mm UTC")
-                                @if (!isExpired)
-                                {
-                                    <span class="time-remaining">(@GetTimeRemainingString(token) remaining)</span>
-                                }
-                            </span>
-                        </div>
-                        @if (token.IsCurrent)
-                        {
-                            <div class="current-session">
-                                <span class="badge badge-primary">Current Session</span>
-                            </div>
-                        }
-                    </div>
-                </div>
+                @RenderTokenItem(token)
             }
         </div>
 
@@ -161,6 +109,29 @@
     }
 </div>
 
+@* ===== Expired Sessions ===== *@
+@if (_expiredTokens.Count > 0)
+{
+    <div class="editor-section">
+        <h3 class="editor-section-title">
+            <i class="bi bi-clock-history"></i>
+            Expired Sessions
+        </h3>
+
+        <div class="tokens-list">
+            @foreach (var token in _expiredTokens)
+            {
+                @RenderTokenItem(token)
+            }
+        </div>
+
+        <div class="token-actions-bulk">
+            <VButton Variant="danger" OnClick="@ClearExpiredSessions">Clear Expired Sessions</VButton>
+            <p class="help-text">This will permanently delete sessions that have expired</p>
+        </div>
+    </div>
+}
+
 </div>
 
 @code {
@@ -168,6 +139,8 @@
     public ModalRoot ModalRoot { get; set; }
 
     private List<AuthTokenInfo> Tokens { get; set; }
+    private List<AuthTokenInfo> _activeTokens = new();
+    private List<AuthTokenInfo> _expiredTokens = new();
     private bool IsLoading { get; set; } = true;
     private Dictionary<string, PublicOauthAppData> _appInfoCache = new();
 
@@ -176,6 +149,20 @@
     private bool IsExpired(AuthTokenInfo token)
     {
         return token.TimeExpires < DateTime.UtcNow;
+    }
+
+    private void SplitTokensByExpiry()
+    {
+        _activeTokens.Clear();
+        _expiredTokens.Clear();
+
+        if (Tokens is null)
+            return;
+
+        foreach (var token in Tokens)
+        {
+            (IsExpired(token) ? _expiredTokens : _activeTokens).Add(token);
+        }
     }
 
     private bool ExpiresSoon(AuthTokenInfo token)
@@ -194,6 +181,57 @@
             return $"{(int)remaining.TotalMinutes} minutes";
         return "less than a minute";
     }
+
+    private RenderFragment RenderTokenItem(AuthTokenInfo token) => @<div class="token-item @(IsExpired(token) ? "expired" : ExpiresSoon(token) ? "expires-soon" : "")">
+        <div class="token-header">
+            <div class="token-app">
+                @if (token.AppId == "VALOUR")
+                {
+                    <img src="../_content/Valour.Client/media/logo/logo-64.png" alt="Valour" class="app-icon" />
+                    <span class="app-name">Valour Web Client</span>
+                }
+                else if (_appInfoCache.TryGetValue(token.AppId, out var appInfo))
+                {
+                    <img src="@appInfo.ImageUrl" alt="@appInfo.Name" class="app-icon" />
+                    <span class="app-name">@appInfo.Name</span>
+                }
+                else
+                {
+                    <img src="../_content/Valour.Client/media/logo/logo-64.png" alt="OAuth App" class="app-icon" />
+                    <span class="app-name">OAuth App (@token.AppId)</span>
+                }
+            </div>
+            <div class="token-actions">
+                @if (!IsExpired(token))
+                {
+                    <VButton Variant="danger" Size="sm" OnClick="@(() => RevokeToken(token))">Revoke</VButton>
+                }
+            </div>
+        </div>
+
+        <div class="token-details">
+            <div class="token-info">
+                <span class="label">Created:</span>
+                <span>@token.TimeCreated.ToString("MMM dd, yyyy 'at' HH:mm UTC")</span>
+            </div>
+            <div class="token-info">
+                <span class="label">Expires:</span>
+                <span class="@(IsExpired(token) ? "expired" : ExpiresSoon(token) ? "expires-soon" : "")">
+                    @token.TimeExpires.ToString("MMM dd, yyyy 'at' HH:mm UTC")
+                    @if (!IsExpired(token))
+                    {
+                        <span class="time-remaining">(@GetTimeRemainingString(token) remaining)</span>
+                    }
+                </span>
+            </div>
+            @if (token.IsCurrent)
+            {
+                <div class="current-session">
+                    <span class="badge badge-primary">Current Session</span>
+                </div>
+            }
+        </div>
+    </div>;
 
     private DateTime? _pendingMfaRemovalAt;
 
@@ -239,6 +277,7 @@
         {
             IsLoading = true;
             Tokens = await Client.AuthService.GetMyTokensAsync();
+            SplitTokensByExpiry();
 
             // Load OAuth app info for non-VALOUR tokens
             await LoadOAuthAppInfo();
@@ -326,6 +365,34 @@
         };
 
         ModalRoot.OpenModal<RevokeTokenModal>(modalParams);
+    }
+
+    private void ClearExpiredSessions()
+    {
+        var expiredCount = _expiredTokens.Count;
+        var modalParams = new RevokeExpiredTokensModal.Params
+        {
+            ExpiredCount = expiredCount,
+            RequireMfa = _multiAuthMethods is { Count: > 0 },
+            OnConfirmAsync = async (code) =>
+            {
+                var result = await ToastContainer.Instance.WaitToastWithTaskResult(new ProgressToastData<TaskResult>()
+                {
+                    ProgressTask = AuthService.RevokeExpiredTokensAsync(code),
+                    Title = "Clearing Expired Sessions",
+                    Message = "Removing expired sessions...",
+                });
+
+                if (result.Success)
+                {
+                    await LoadTokens();
+                }
+
+                return result;
+            }
+        };
+
+        ModalRoot.OpenModal<RevokeExpiredTokensModal>(modalParams);
     }
 
     // ===== MFA =====

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditSessionsComponent.razor.css
@@ -147,10 +147,6 @@
     margin-left: 0.5rem;
 }
 
-.current-session {
-    margin-top: 0.5rem;
-}
-
 /* Badge styling */
 .badge {
     padding: 0.2rem 0.6rem;

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/RevokeExpiredTokensModal.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/RevokeExpiredTokensModal.razor
@@ -1,0 +1,58 @@
+@inherits Modal<RevokeExpiredTokensModal.Params>
+
+<BasicModalLayout Title="Clear Expired Sessions" Icon="shield-lock-fill" MaxWidth="400px">
+    <MainArea>
+        <p>
+            This will permanently delete @Data.ExpiredCount expired session@(Data.ExpiredCount == 1 ? "" : "s").
+            This cannot be undone.
+        </p>
+
+        @if (Data.RequireMfa)
+        {
+            <div class="form-group">
+                <label>Authenticator code</label>
+                <input class="v-input" inputmode="numeric" autocomplete="one-time-code" maxlength="8"
+                       placeholder="000000" @bind="_mfaCode" />
+                <ResultLabel Style="margin-top: 1em" Result="@_result" />
+            </div>
+        }
+    </MainArea>
+    <ButtonArea>
+        <div class="basic-modal-buttons">
+            <button @onclick="@OnCancel" class="v-btn">Cancel</button>
+            <button @onclick="@OnConfirm" class="v-btn danger" disabled="@(Data.RequireMfa && string.IsNullOrWhiteSpace(_mfaCode))">Clear Expired Sessions</button>
+        </div>
+    </ButtonArea>
+</BasicModalLayout>
+
+@code {
+    public class Params
+    {
+        public int ExpiredCount { get; set; }
+        public bool RequireMfa { get; set; }
+        public Func<string, Task<TaskResult>> OnConfirmAsync { get; set; }
+    }
+
+    private string _mfaCode = "";
+    private ITaskResult _result;
+
+    private async Task OnConfirm()
+    {
+        if (Data.OnConfirmAsync is not null)
+        {
+            var result = await Data.OnConfirmAsync.Invoke(_mfaCode);
+            _result = result;
+
+            if (result.Success)
+            {
+                Close();
+            }
+            else
+            {
+                StateHasChanged();
+            }
+        }
+    }
+
+    private void OnCancel() => Close();
+}

--- a/Valour/Sdk/Services/AuthService.cs
+++ b/Valour/Sdk/Services/AuthService.cs
@@ -767,6 +767,17 @@ public class AuthService : ServiceBase
     }
 
     /// <summary>
+    /// Revokes all expired tokens. If MFA is enabled on the account, a valid authenticator
+    /// code must be provided.
+    /// </summary>
+    public async Task<TaskResult> RevokeExpiredTokensAsync(string mfaCode = null)
+    {
+        return await _client.PrimaryNode.PostAsync(
+            "api/users/me/tokens/expired/revoke",
+            new RevokeExpiredTokensRequest { MultiFactorCode = mfaCode });
+    }
+
+    /// <summary>
     /// Logs out the current user (revokes current token) and clears local auth state.
     /// The server call is best-effort: local state is cleared even if it fails so the
     /// device never keeps using a token the user asked to revoke.

--- a/Valour/Server/Api/Dynamic/UserApi.cs
+++ b/Valour/Server/Api/Dynamic/UserApi.cs
@@ -247,6 +247,31 @@ public class UserApi
         return Results.Ok(result.Message);
     }
 
+    [ValourRoute(HttpVerbs.Post, "api/users/me/tokens/expired/revoke")]
+    public static async Task<IResult> RevokeExpiredTokensRouteAsync(
+        [FromBody] RevokeExpiredTokensRequest request,
+        UserService userService,
+        MultiAuthService multiAuthService)
+    {
+        var user = await userService.GetCurrentUserAsync();
+        if (user is null)
+            return ValourResult.NotFound<User>();
+
+        var mfaMethods = await multiAuthService.GetAppMultiAuthTypes(user.Id);
+        if (mfaMethods.Count > 0)
+        {
+            var mfa = await multiAuthService.VerifyEstablishedAppMultiAuth(user.Id, request?.MultiFactorCode);
+            if (!mfa.Success)
+                return ValourResult.BadRequest(mfa.Message);
+        }
+
+        var result = await userService.RevokeExpiredTokensAsync(user.Id);
+        if (!result.Success)
+            return ValourResult.Problem(result.Message);
+
+        return Results.Ok(result.Message);
+    }
+
     /// <summary>
     /// Returns when a staff-scheduled MFA removal will execute for the
     /// current account, or 404 if none is pending.

--- a/Valour/Server/Services/UserService.cs
+++ b/Valour/Server/Services/UserService.cs
@@ -678,14 +678,15 @@ public class UserService
     }
 
     /// <summary>
-    /// Revokes all tokens for a user except the current one
+    /// Revokes all active (non-expired) tokens for a user except the current one.
+    /// Expired tokens are left alone; use RevokeExpiredTokensAsync to clear those.
     /// </summary>
     public async Task<TaskResult> RevokeAllOtherTokensAsync(long userId, string currentTokenId)
     {
         try
         {
             var tokens = await _db.AuthTokens
-                .Where(x => x.UserId == userId && x.Id != currentTokenId)
+                .Where(x => x.UserId == userId && x.Id != currentTokenId && x.TimeExpires > DateTime.UtcNow)
                 .ToListAsync();
 
             _db.AuthTokens.RemoveRange(tokens);
@@ -699,6 +700,35 @@ public class UserService
             }
 
             return new TaskResult(true, $"Revoked {tokens.Count} tokens");
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e.Message);
+            return new TaskResult(false, e.Message);
+        }
+    }
+
+    /// <summary>
+    /// Revokes all expired tokens for a user
+    /// </summary>
+    public async Task<TaskResult> RevokeExpiredTokensAsync(long userId)
+    {
+        try
+        {
+            var tokens = await _db.AuthTokens
+                .Where(x => x.UserId == userId && x.TimeExpires < DateTime.UtcNow)
+                .ToListAsync();
+
+            _db.AuthTokens.RemoveRange(tokens);
+            await _db.SaveChangesAsync();
+
+            // Evict after commit to avoid re-cache race
+            foreach (var token in tokens)
+            {
+                _tokenService.RemoveFromQuickCache(token.Id);
+            }
+
+            return new TaskResult(true, $"Revoked {tokens.Count} expired session(s)");
         }
         catch (Exception e)
         {

--- a/Valour/Shared/Models/RevokeExpiredTokensRequest.cs
+++ b/Valour/Shared/Models/RevokeExpiredTokensRequest.cs
@@ -1,0 +1,6 @@
+namespace Valour.Shared.Models;
+
+public sealed class RevokeExpiredTokensRequest
+{
+    public string MultiFactorCode { get; set; }
+}


### PR DESCRIPTION
## Summary
- Adds a "Clear Expired Sessions" flow: new `POST api/users/me/tokens/expired/revoke` endpoint, `UserService.RevokeExpiredTokensAsync`, and `RevokeExpiredTokensModal.razor` (with MFA re-verification when the account has MFA enabled).
- Splits the Sessions screen into separate "Active Sessions" and "Expired Sessions" sections, each with their own bulk action ("Revoke All Other Sessions" / "Clear Expired Sessions").
- `RevokeAllOtherTokensAsync` now only revokes active (non-expired) tokens, so it no longer clobbers sessions the new "Clear Expired Sessions" flow is meant to handle.
- Moves the "Current Session" badge next to the app name in the session card header, instead of at the bottom of the details block.
- Minor perf cleanup: active/expired token lists are computed once per load instead of via repeated LINQ `.Where()` calls on every render.
