### PR TITLE
0.7.16: Fix voice calls being killed by reconciliation

### DIFF
--- a/Valour/Client.Maui/Valour.Client.Maui.csproj
+++ b/Valour/Client.Maui/Valour.Client.Maui.csproj
@@ -50,8 +50,8 @@
         <ApplicationId>gg.valour.app</ApplicationId>
 
         <!-- Versions -->
-        <ApplicationDisplayVersion>0.7.15</ApplicationDisplayVersion>
-        <ApplicationVersion>85</ApplicationVersion>
+        <ApplicationDisplayVersion>0.7.16</ApplicationDisplayVersion>
+        <ApplicationVersion>86</ApplicationVersion>
 
         <!-- To develop, package, and publish an app to the Microsoft Store, see: https://aka.ms/MauiTemplateUnpackaged -->
         <WindowsPackageType>None</WindowsPackageType>

--- a/Valour/Sdk/Valour.Sdk.csproj
+++ b/Valour/Sdk/Valour.Sdk.csproj
@@ -13,7 +13,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ImplicitUsings>true</ImplicitUsings>
     <DebugType>portable</DebugType>
-    <Version>0.7.15</Version>
+    <Version>0.7.16</Version>
     <RootNamespace>Valour.Sdk</RootNamespace>
     <Nullable>annotations</Nullable>
   </PropertyGroup>

--- a/Valour/Server/Services/IVoiceProvider.cs
+++ b/Valour/Server/Services/IVoiceProvider.cs
@@ -51,10 +51,12 @@ public interface IVoiceProvider
     Task<TaskResult> CloseMeetingAsync(string meetingId, string reason, long? channelId = null);
 
     /// <summary>
-    /// The backend's authoritative view of who is connected to a channel's meeting.
-    /// Returns the set of Valour user ids, or null when the backend could not be
-    /// queried (in which case reconciliation for that channel is skipped so live
-    /// participants are never wrongly removed).
+    /// The backend's view of who is connected to a channel's meeting. Returns the set
+    /// of Valour user ids, or null when the backend gave no positive evidence — a
+    /// failed query, or a "nobody connected" answer that cannot be distinguished from
+    /// a broken/lagging reporting surface. Callers treat null as "cannot verify" and
+    /// skip reconciliation for that channel; kicking users requires a non-null set.
+    /// Redis heartbeat TTLs remain the fallback cleanup for truly-departed users.
     /// </summary>
     Task<HashSet<long>?> GetConnectedUserIdsAsync(long channelId, string meetingId);
 

--- a/Valour/Server/Services/RealtimeKitService.cs
+++ b/Valour/Server/Services/RealtimeKitService.cs
@@ -389,15 +389,26 @@ public class RealtimeKitService : IVoiceProvider
     }
 
     /// <summary>
-    /// The backend's authoritative connected-user set for a meeting: unions the
-    /// live sessions' participants (excluding those that have left). Returns null
-    /// when Cloudflare could not be queried, so the caller skips reconciliation
-    /// rather than removing live participants.
+    /// The backend's connected-user set for a meeting: unions the live sessions'
+    /// participants (excluding those that have left). Returns null whenever Cloudflare
+    /// gives no positive evidence of who is connected — query failure, zero live
+    /// sessions, a failed per-session participant fetch, or zero parsed users — so the
+    /// caller skips reconciliation rather than removing live participants.
+    ///
+    /// The sessions endpoint is a reporting API, not the SFU itself, and it has been
+    /// observed returning success with an empty session list for meetings that had
+    /// multiple connected users (no sessions recorded app-wide after 2026-03-13).
+    /// Treating that empty answer as truth kicked every participant of every active
+    /// call on each reconciliation pass. Truly-departed users are still cleaned up by
+    /// the Redis heartbeat TTL, so skipping here loses nothing.
     /// </summary>
     public async Task<HashSet<long>?> GetConnectedUserIdsAsync(long channelId, string meetingId)
     {
         var sessionsResult = await GetLiveSessionsForMeetingAsync(meetingId);
         if (!sessionsResult.Success || sessionsResult.Data is null)
+            return null;
+
+        if (sessionsResult.Data.Count == 0)
             return null;
 
         var userIds = new HashSet<long>();
@@ -408,7 +419,7 @@ public class RealtimeKitService : IVoiceProvider
 
             var participantsResult = await GetSessionParticipantsAsync(session.Id);
             if (!participantsResult.Success || participantsResult.Data is null)
-                continue;
+                return null;
 
             foreach (var participant in participantsResult.Data)
             {
@@ -420,6 +431,9 @@ public class RealtimeKitService : IVoiceProvider
                     userIds.Add(userId.Value);
             }
         }
+
+        if (userIds.Count == 0)
+            return null;
 
         return userIds;
     }
@@ -453,8 +467,10 @@ public class RealtimeKitService : IVoiceProvider
 
     private static bool IsPastOrphanSessionGracePeriod(CloudflareSessionInfo session)
     {
+        // An unparseable timestamp means the grace period cannot be evaluated;
+        // keep the session rather than risk closing one that just started.
         if (!DateTimeOffset.TryParse(session.CreatedAt, out var createdAt))
-            return true;
+            return false;
 
         return DateTimeOffset.UtcNow - createdAt.ToUniversalTime() >= OrphanSessionGracePeriod;
     }

--- a/Valour/Server/Workers/VoiceStateCleanupWorker.cs
+++ b/Valour/Server/Workers/VoiceStateCleanupWorker.cs
@@ -187,7 +187,8 @@ public class VoiceStateCleanupWorker : BackgroundService
     /// removing users from Redis/HostedPlanet that the backend no longer sees. The
     /// backend's live truth is fetched provider-agnostically via
     /// <see cref="IVoiceProvider.GetConnectedUserIdsAsync"/>; a null result (backend
-    /// unreachable) skips that channel so live participants are never wrongly removed.
+    /// unreachable, or no positive evidence of who is connected) skips that channel
+    /// so live participants are never wrongly removed.
     /// </summary>
     private async Task ReconcileWithProviderAsync()
     {
@@ -319,6 +320,14 @@ public class VoiceStateCleanupWorker : BackgroundService
     {
         var trackedMeetings = await _voiceProvider.LoadOpenMeetingMappingsAsync();
         var participantCountsByChannel = await GetRedisParticipantCountsByChannelAsync();
+        if (participantCountsByChannel is null)
+        {
+            _logger.LogWarning(
+                "Skipping voice meeting cleanup ({Reason}): Redis participant counts are unavailable",
+                reason);
+            return;
+        }
+
         var checkedMeetings = 0;
         var keptMeetings = 0;
         var closedMeetings = 0;
@@ -362,7 +371,11 @@ public class VoiceStateCleanupWorker : BackgroundService
             failedMeetings);
     }
 
-    private async Task<Dictionary<long, int>> GetRedisParticipantCountsByChannelAsync()
+    /// <summary>
+    /// Returns null when Redis cannot be read — the caller must skip cleanup rather
+    /// than treat every meeting as empty and close live calls.
+    /// </summary>
+    private async Task<Dictionary<long, int>?> GetRedisParticipantCountsByChannelAsync()
     {
         var result = new Dictionary<long, int>();
 
@@ -371,7 +384,7 @@ public class VoiceStateCleanupWorker : BackgroundService
             var db = _redis.GetDatabase(RedisDbTypes.Cluster);
             var servers = _redis.GetServers();
             if (servers.Length == 0)
-                return result;
+                return null;
 
             var channelKeys = servers
                 .SelectMany(server => server.Keys(RedisDbTypes.Cluster, "voice:channel:*"))
@@ -408,9 +421,9 @@ public class VoiceStateCleanupWorker : BackgroundService
         {
             _logger.LogWarning(
                 ex,
-                "Could not read Redis voice participant counts for meeting cleanup; treating all active meetings as unused");
+                "Could not read Redis voice participant counts for meeting cleanup; skipping this cleanup pass");
+            return null;
         }
-
 
         return result;
     }

--- a/Valour/Shared/Valour.Shared.csproj
+++ b/Valour/Shared/Valour.Shared.csproj
@@ -13,7 +13,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <ImplicitUsings>true</ImplicitUsings>
     <DebugType>portable</DebugType>
-    <Version>0.7.15</Version>
+    <Version>0.7.16</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/Valour/Tests/Services/RealtimeKitReconciliationTests.cs
+++ b/Valour/Tests/Services/RealtimeKitReconciliationTests.cs
@@ -1,0 +1,157 @@
+using System.Net;
+using System.Text;
+using Microsoft.Extensions.Logging.Abstractions;
+using Valour.Config.Configs;
+using Valour.Server.Services;
+
+namespace Valour.Tests.Services;
+
+/// <summary>
+/// Regression tests for the voice reconciliation data source. Cloudflare's sessions
+/// API stopped recording sessions (success + empty list) while calls had live
+/// participants, and reconciliation kicked every participant of every active call
+/// each pass. GetConnectedUserIdsAsync must return null — "cannot verify" — for any
+/// answer that lacks positive evidence of who is connected.
+/// </summary>
+public class RealtimeKitReconciliationTests
+{
+    private const string EmptySessionsBody =
+        """{"success":true,"data":{"sessions":[]},"paging":{"total_count":0,"start_offset":1,"end_offset":0}}""";
+
+    private const string OneLiveSessionBody =
+        """{"success":true,"data":{"sessions":[{"id":"sess-1","associated_id":"meet-1","created_at":"2026-07-26T19:17:27.646Z","status":"LIVE","live_participants":2}]}}""";
+
+    public RealtimeKitReconciliationTests()
+    {
+        // The service reads config from the static instance; the ctor assigns it.
+        _ = new CloudflareConfig
+        {
+            RealtimeAccountId = "test-account",
+            RealtimeAppId = "test-app",
+            RealtimeApiToken = "test-token"
+        };
+    }
+
+    [Fact]
+    public async Task EmptyLiveSessionList_ReturnsNull()
+    {
+        // The exact prod failure: success:true with zero sessions for a meeting
+        // that had three connected users.
+        var service = CreateService(new RouteHandler
+        {
+            ["/sessions?"] = (HttpStatusCode.OK, EmptySessionsBody)
+        });
+
+        var result = await service.GetConnectedUserIdsAsync(1, "meet-1");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task SessionsQueryFailure_ReturnsNull()
+    {
+        var service = CreateService(new RouteHandler
+        {
+            ["/sessions?"] = (HttpStatusCode.InternalServerError,
+                """{"success":false,"errors":[{"code":500,"message":"boom"}]}""")
+        });
+
+        var result = await service.GetConnectedUserIdsAsync(1, "meet-1");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ParticipantsQueryFailure_ReturnsNull()
+    {
+        // A session exists but its participant list cannot be fetched; partial data
+        // must not read as "those users left".
+        var service = CreateService(new RouteHandler
+        {
+            ["/sessions/sess-1/participants"] = (HttpStatusCode.InternalServerError,
+                """{"success":false,"errors":[{"code":500,"message":"boom"}]}"""),
+            ["/sessions?"] = (HttpStatusCode.OK, OneLiveSessionBody)
+        });
+
+        var result = await service.GetConnectedUserIdsAsync(1, "meet-1");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task AllParticipantsLeft_ReturnsNull()
+    {
+        var service = CreateService(new RouteHandler
+        {
+            ["/sessions/sess-1/participants"] = (HttpStatusCode.OK,
+                """{"success":true,"data":{"participants":[{"id":"p1","custom_participant_id":"123:abc","left_at":"2026-07-26T19:18:00.000Z"}]}}"""),
+            ["/sessions?"] = (HttpStatusCode.OK, OneLiveSessionBody)
+        });
+
+        var result = await service.GetConnectedUserIdsAsync(1, "meet-1");
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConnectedParticipants_ReturnsTheirUserIds()
+    {
+        var service = CreateService(new RouteHandler
+        {
+            ["/sessions/sess-1/participants"] = (HttpStatusCode.OK,
+                """{"success":true,"data":{"participants":[{"id":"p1","custom_participant_id":"123:abc","left_at":null},{"id":"p2","custom_participant_id":"456","left_at":null},{"id":"p3","custom_participant_id":"789","left_at":"2026-07-26T19:18:00.000Z"}]}}"""),
+            ["/sessions?"] = (HttpStatusCode.OK, OneLiveSessionBody)
+        });
+
+        var result = await service.GetConnectedUserIdsAsync(1, "meet-1");
+
+        Assert.NotNull(result);
+        Assert.Equal(new HashSet<long> { 123, 456 }, result);
+    }
+
+    private static RealtimeKitService CreateService(RouteHandler handler) =>
+        new(new StubHttpClientFactory(handler),
+            NullLogger<RealtimeKitService>.Instance,
+            new EmptyServiceProvider());
+
+    /// <summary>
+    /// Routes requests by first matching URL substring; unmatched requests fail the test.
+    /// </summary>
+    private sealed class RouteHandler : HttpMessageHandler
+    {
+        private readonly List<(string Fragment, HttpStatusCode Status, string Body)> _routes = new();
+
+        public (HttpStatusCode, string) this[string urlFragment]
+        {
+            set => _routes.Add((urlFragment, value.Item1, value.Item2));
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var url = request.RequestUri!.ToString();
+            foreach (var (fragment, status, body) in _routes)
+            {
+                if (url.Contains(fragment, StringComparison.Ordinal))
+                {
+                    return Task.FromResult(new HttpResponseMessage(status)
+                    {
+                        Content = new StringContent(body, Encoding.UTF8, "application/json")
+                    });
+                }
+            }
+
+            throw new InvalidOperationException($"Unexpected request in test: {url}");
+        }
+    }
+
+    private sealed class StubHttpClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+
+    private sealed class EmptyServiceProvider : IServiceProvider
+    {
+        public object? GetService(Type serviceType) => null;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes users being kicked from voice chats every ~2 minutes and having to rejoin.

**Root cause:** Cloudflare's RealtimeKit sessions API has silently stopped recording sessions for our app (nothing since 2026-03-13) — it returns `success: true` with an empty session list even for meetings with live participants. The reconciliation sweep (shipped 7/18 in "SH Voice/Video") treated that empty answer as "nobody is connected", so every pass kicked all heartbeating participants from Redis and closed the meeting. Verified against prod logs (3-person call killed 115s after meeting creation, twice in a row) and direct Cloudflare API probes.

**Fix:** `GetConnectedUserIdsAsync` returns null ("cannot verify" → reconciliation skips) instead of an empty set when the sessions list is empty, a per-session participant fetch fails, or no users parse. Kicking users now requires positive evidence from the backend; genuinely-departed users are still cleaned up by the Redis heartbeat TTL (45s heartbeat / 120s TTL / 30s sweep), so nothing is lost.

**Additional fail-safe hardening in the cleanup worker:**
- A Redis read failure now skips the tracked-meeting sweep instead of treating every meeting as empty and closing all live calls
- An unparseable session `created_at` no longer counts as past the orphan grace period

LiveKit is unchanged — its SFU participant list is authoritative, per the live-test contract.

## Testing
- 5 new regression tests in `RealtimeKitReconciliationTests` covering the exact prod failure shape (empty session list), failed participant fetches, all-left sessions, and the healthy positive path
- Existing voice tests pass; server builds clean

Also bumps versions to 0.7.16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)