### PR TITLE
Fix: FetchMessageAsync using nonexistent api/message/{id} route

### DIFF
--- a/Valour/Sdk/Services/MessageService.cs
+++ b/Valour/Sdk/Services/MessageService.cs
@@ -54,18 +54,18 @@ public class MessageService : ServiceBase
         if (!skipCache && _client.Cache.Messages.TryGet(id, out var cached))
             return cached;
         
-        var response = await _client.PrimaryNode.GetJsonAsync<Message>($"api/message/{id}");
+        var response = await _client.PrimaryNode.GetJsonAsync<Message>($"api/messages/{id}");
 
         return response.Data.Sync(_client);
     }
-    
+
     public async ValueTask<Message> FetchMessageAsync(long id, Planet planet, bool skipCache = false)
     {
         var scope = planet?.Node?.IsExternal == true ? planet.Node.Name : null;
         if (!skipCache && _client.Cache.Messages.TryGet(id, scope, out var cached))
             return cached;
-        
-        var response = await (planet?.Node ?? _client.PrimaryNode).GetJsonAsync<Message>($"api/message/{id}");
+
+        var response = await (planet?.Node ?? _client.PrimaryNode).GetJsonAsync<Message>($"api/messages/{id}");
 
         return response.Data.Sync(_client);
     }


### PR DESCRIPTION
## Summary
- `MessageService.FetchMessageAsync` (both overloads) called `api/message/{id}` (singular), which doesn't exist — the actual server route is `api/messages/{id}` (`MessageApi.cs:260`), causing every direct message fetch by id to 404.
- Updated both call sites to use the correct plural route.
