### PR TITLE
Add "Mark as Read" to channel/category right-click menu

### DIFF
--- a/Valour/Client/ContextMenu/Menus/ChannelContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/ChannelContextMenu.razor
@@ -54,6 +54,13 @@
         </ContextMenuItem>
     }
 }
+@if (Data.Channel.PlanetId is not null)
+{
+    <ContextMenuItem OnClickAsync="@MarkAsRead">
+        <Label>Mark as Read</Label>
+        <Icon><i class="bi bi-check2-circle"></i></Icon>
+    </ContextMenuItem>
+}
 @if (HasActivityAlerts && _activityAlertsLoaded)
 {
     if (_activityAlerts == ChannelActivityAlerts.Off)
@@ -127,6 +134,42 @@
             _activityAlerts = await Data.Channel.FetchActivityAlertsAsync();
             _activityAlertsLoaded = true;
             StateHasChanged();
+        }
+    }
+
+    private async Task MarkAsRead()
+    {
+        await CloseAsync();
+
+        var channels = new List<Channel>();
+
+        if (Data.Channel.ChannelType == ChannelTypeEnum.PlanetCategory)
+        {
+            CollectChannelsInCategory(Data.Channel.Id, channels);
+        }
+        else
+        {
+            channels.Add(Data.Channel);
+        }
+
+        foreach (var channel in channels)
+        {
+            Client.UnreadService.MarkChannelRead(channel.PlanetId, channel.Id);
+            _ = channel.UpdateUserState(DateTime.UtcNow);
+        }
+    }
+
+    private void CollectChannelsInCategory(long categoryId, List<Channel> results)
+    {
+        foreach (var channel in Data.Channel.Planet.Channels)
+        {
+            if (channel.ParentId != categoryId)
+                continue;
+
+            if (channel.ChannelType == ChannelTypeEnum.PlanetCategory)
+                CollectChannelsInCategory(channel.Id, results);
+            else
+                results.Add(channel);
         }
     }
 


### PR DESCRIPTION
## Summary
- Right-clicking a channel or category now shows a "Mark as Read" option in the context menu (`ChannelContextMenu.razor`).
- Marking a single channel as read clears its unread dot both locally (`UnreadService.MarkChannelRead`) and on the server (`Channel.UpdateUserState`), matching the existing behavior when a channel is opened.
- Marking a category as read recursively marks every channel inside it, including channels in nested sub-categories, as read.
