### PR TITLE
Synchronize 'About OAuth' appearance with 'About Bots'

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditOAuthComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditOAuthComponent.razor.css
@@ -110,23 +110,21 @@
 }
 
 .info-item {
-    padding: 0.85rem 1rem;
-    background-color: var(--main-3);
-    border: 1px solid var(--slight-tint);
+    padding: 1rem;
+    background-color: var(--main-4);
     border-radius: var(--radius-md);
+    border-left: 3px solid var(--color-primary);
 }
 
 .info-item h4 {
-    margin: 0 0 0.35rem 0;
+    margin: 0 0 0.5rem 0;
     color: var(--font-color);
-    font-size: var(--font-size-sm);
-    font-weight: var(--font-weight-medium);
+    font-size: var(--font-size-lg);
 }
 
 .info-item p {
     margin: 0;
-    font-size: var(--font-size-xs);
-    color: var(--font-alt-color);
+    color: var(--font-color-muted);
     line-height: var(--line-height-relaxed);
 }
 


### PR DESCRIPTION
Before:
<img width="902" height="459" alt="image" src="https://github.com/user-attachments/assets/c1a388e8-b20e-4af9-9547-4353c37345e0" />

After:
<img width="903" height="541" alt="image" src="https://github.com/user-attachments/assets/7b199ae7-1818-41b2-82b9-c205453bc3df" />
