### PR TITLE
Fix NullReferenceException on invite/discover screens before login

### DIFF
--- a/Valour/Sdk/Services/PlanetService.cs
+++ b/Valour/Sdk/Services/PlanetService.cs
@@ -108,6 +108,16 @@ public class PlanetService : ServiceBase
     }
 
     /// <summary>
+    /// Public-facing screens (e.g. invite/discover) can be reached before login,
+    /// when SetupPrimaryNodeAsync has not yet run as part of the auth flow. This
+    /// ensures a primary node connection exists so those requests don't NRE.
+    /// </summary>
+    private Task EnsurePrimaryNodeAsync() =>
+        _client.PrimaryNode is null
+            ? _client.NodeService.SetupPrimaryNodeAsync()
+            : Task.CompletedTask;
+
+    /// <summary>
     /// Retrieves and returns a client planet by requesting from the server
     /// </summary>
     public async ValueTask<Planet> FetchPlanetAsync(long id, bool skipCache = false)
@@ -208,8 +218,11 @@ public class PlanetService : ServiceBase
         return invite.Sync(_client);
     }
 
-    public Task<TaskResult<PlanetListInfo>> FetchInviteScreenDataAsync(string code) =>
-        _client.PrimaryNode.GetJsonAsync<PlanetListInfo>($"{ISharedPlanetInvite.BaseRoute}/{code}/screen");
+    public async Task<TaskResult<PlanetListInfo>> FetchInviteScreenDataAsync(string code)
+    {
+        await EnsurePrimaryNodeAsync();
+        return await _client.PrimaryNode.GetJsonAsync<PlanetListInfo>($"{ISharedPlanetInvite.BaseRoute}/{code}/screen");
+    }
 
     /// <summary>
     /// Imports a Discord server template (discord.new link or plain code) as a
@@ -225,6 +238,7 @@ public class PlanetService : ServiceBase
     /// </summary>
     public async Task<TaskResult<PlanetListInfo>> FetchPlanetInfoAsync(long planetId)
     {
+        await EnsurePrimaryNodeAsync();
         var response = await _client.PrimaryNode.GetJsonAsync<PlanetListInfo>($"api/planets/{planetId}/info");
         if (!response.Success)
             return TaskResult<PlanetListInfo>.FromFailure(response.Message);


### PR DESCRIPTION
## Summary
- `PlanetService.FetchInviteScreenDataAsync` and `PlanetService.FetchPlanetInfoAsync` called `_client.PrimaryNode` directly, but `PrimaryNode` is only initialized as part of the login flow (`SetupPrimaryNodeAsync`).
- Navigating to `/I/<invite code>` or `/D/<planetId>` without a prior session (or after a session expired) left `PrimaryNode` null, crashing the WASM renderer with an unhandled `NullReferenceException` (blank screen).
- Added `PlanetService.EnsurePrimaryNodeAsync()`, which lazily sets up the primary node if it isn't already connected — the same guard `AuthService.LoginAsync` already uses — and call it from both methods before touching `PrimaryNode`.

Fixes #1618 (also addresses the `/D/` case mentioned in that issue's comments)

## Test plan
- [x] `dotnet build Valour.Sdk.csproj` — succeeds
- [x] `dotnet build Valour.Client.csproj` (contains `Invite.razor`/`Discover.razor`, the call sites) — succeeds
- Not manually tested against a running server (no local dev environment set up) — reasoning verified by code inspection: `SetupPrimaryNodeAsync` calls the unauthenticated `api/node/name` endpoint, matching the pattern already used pre-login in `AuthService.LoginAsync`.