### PR TITLE
Fix Victor's welcome message wrongly calling planets "HostedPlanets"

### DIFF
--- a/Valour/Server/Services/RegisterService.cs
+++ b/Valour/Server/Services/RegisterService.cs
@@ -17,7 +17,7 @@ public class RegisterService
     private const string ValourWelcome = "## Welcome to Valour!\nI'm *Victor*, the Valour mascot. I'm here to help you get started. " +
                                          "If you have any questions, feel free to ask me. I may not be fast to respond (I am run by humans!) " +
                                          "You can also ask other users, or check out the Valour Central planet for more information." +
-                                         " Some basics: \n- Valour communities are named HostedPlanets! You can join or create planets for your interests. " +
+                                         " Some basics: \n- Valour communities are named Planets! You can join or create planets for your interests. " +
                                          "\n- You can also add friends and direct message them. " +
                                          "\n- Valour (desktop) supports opening multiple windows with controls on the top right of each window. ";
     


### PR DESCRIPTION
## Summary
- Victor's onboarding DM told new users "Valour communities are named HostedPlanets!" — `HostedPlanets` is an unrelated internal model/type name (used for planet hosting/caching on the server) that leaked into the user-facing copy.
- Changed the string in `RegisterService.cs` to say "Planets" instead.

Fixes #1645

## Test plan
- [x] `dotnet build Valour.Server.csproj` on `version/0.8.0` — succeeds, 0 errors
- [x] Confirmed via grep this is the only occurrence of the typo in the codebase