### PR TITLE
Fix reply disappearing when editing the message that has one

### DIFF
--- a/Valour/Server/Services/MessageService.cs
+++ b/Valour/Server/Services/MessageService.cs
@@ -398,6 +398,10 @@ public class MessageService
         Message stagedOld = null;
         
         var dbOld = await _db.Messages
+            .Include(x => x.ReplyToMessage)
+                .ThenInclude(x => x.Attachments)
+            .Include(x => x.ReplyToMessage)
+                .ThenInclude(x => x.Mentions)
             .Include(x => x.Attachments)
             .Include(x => x.Mentions)
             .Include(x => x.Reactions)


### PR DESCRIPTION
## Summary

Root cause: `MessageService.EditMessageAsync`'s query for the message being edited (`dbOld`) doesn't `Include(x => x.ReplyToMessage)`, unlike every other message-fetch query in this file (`GetMessageAsync`, the message-history queries, etc. all include it).

`Message.ToModel()` computes `ReplyTo = message.ReplyToMessage?.ToModel()` from that navigation property. Since it wasn't loaded, `oldModel.ReplyTo` came back `null`, and `EditMessageAsync` copies that onto the response (`updated.ReplyTo = oldModel.ReplyTo;`) — `ReplyToId` is preserved correctly (it's a plain scalar column), but the nested `ReplyTo` object is not.

On the client, the SDK's generic model-sync/cache-merge logic (`ModelStore.HandleChanges`) reflects over all public properties and copies every one from the incoming edit response onto the cached message — including `ReplyTo` — so the previously-correct cached `ReplyTo` gets overwritten with `null`. This matches the reported symptom exactly: the reply banner disappears after editing, but reappears after a refresh, because a full page load re-fetches the message through a query that does include `ReplyToMessage`.

Fix: add the same `.Include(x => x.ReplyToMessage).ThenInclude(...)` pair used elsewhere in this file to the `dbOld` query in `EditMessageAsync`.

Fixes #1627

## Test plan
- [x] `dotnet build Valour.Server.csproj` on `version/0.8.0` — succeeds, 0 errors (same pre-existing warnings as base, unrelated to this change)
- [x] Confirmed by inspection that every other message-fetch query in `MessageService.cs` already includes `ReplyToMessage` the same way — this brings `EditMessageAsync` in line with that pattern
- Did not run the live integration suite (`Valour.Tests`, e.g. `MessageReplyDeletionLiveTests.cs`) — it requires a running server + database, which isn't available in this environment. A live test asserting `ReplyTo` survives an edit (mirroring the existing reply-deletion live test) would be a good addition if a maintainer wants one.