### PR TITLE
Add spoiler markdown and spoilered attachments

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor
@@ -37,6 +37,13 @@
                 }
             }
         </div>
+        @if (Data.Attachment.Type is MessageAttachmentType.Image or MessageAttachmentType.Video)
+        {
+            <label class="spoiler-toggle">
+                <input type="checkbox" checked="@Data.Attachment.IsSpoiler" @onchange="OnSpoilerToggled" />
+                Mark as spoiler
+            </label>
+        }
         @if (_isUploading)
         {
             <div class="upload-progress-container">
@@ -121,6 +128,12 @@
         }
         
         _loaded = true;
+    }
+
+    private void OnSpoilerToggled(ChangeEventArgs e)
+    {
+        Data.Attachment.IsSpoiler = e.Value is bool value && value;
+        StateHasChanged();
     }
 
     [JSInvokable]

--- a/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Upload/FileUploadComponent.razor.css
@@ -43,6 +43,17 @@
     margin-bottom: 10px;
 }
 
+.spoiler-toggle {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    justify-content: center;
+    font-size: var(--font-size-sm);
+    color: rgba(255, 255, 255, 0.8);
+    cursor: pointer;
+    margin-bottom: 10px;
+}
+
 .upload-progress-container {
     width: 100%;
     height: 8px;

--- a/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
+++ b/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
@@ -41,9 +41,8 @@
                 ? $"max-width: min({MaxSize}px, 100%); height: 200px;"
                 : $"max-width: min({MaxSize}px, 100%);";
 
-        // This also sizes the spoiler placeholder (see markup below) - since
-        // LazyImage isn't rendered while hidden, nothing else is competing to
-        // size the wrapper.
+        // This also sizes the spoiler placeholder (see markup below) - since LazyImage
+        // isn't rendered while hidden, nothing else is competing to size the wrapper.
         if (DoAspect)
             return $"aspect-ratio: {_width} / {_height}; max-width: min({MaxSize}px, 100%); width: {_width}px";
 

--- a/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
+++ b/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
@@ -33,9 +33,9 @@
     private string GetWrapperStyle()
     {
         // No size metadata (e.g. older thread attachments): let the image
-        // render at natural size, clamped by the max constraints below. The
-        // spoiler blur/overlay are both position:absolute though, so with no
-        // size to go on they'd collapse to nothing - give them a fixed height.
+        // render at natural size, clamped by the max constraints below.
+        // The spoiler blur/overlay are both position:absolute though,
+        // so without size to go on they'd collapse to nothing - give them a fixed height.
         if (_width <= 0 || _height <= 0)
             return IsHiddenSpoiler
                 ? $"max-width: min({MaxSize}px, 100%); height: 200px;"

--- a/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
+++ b/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor
@@ -1,14 +1,24 @@
 ﻿@using Valour.Client.Components.Menus.Modals.Attachments
 @inherits AttachmentComponent
 
-<div class="image-attachment-wrapper" style="@GetWrapperStyle()" @onclick="OnClick">
-    <LazyImage CssClass="attached-image"
-               Style="@GetImageStyle()"
-               Alt="@Attachment.FileName"
-               Src="@_location"
-               FallbackSrc="_content/Valour.Client/media/image-not-found.webp"
-               RootMargin="400px 0px"
-               data-og-src="@Attachment.Location" />
+<div class="image-attachment-wrapper @(IsHiddenSpoiler ? "spoiler-hidden" : "")" style="@GetWrapperStyle()" @onclick="OnClick">
+    @if (IsHiddenSpoiler)
+    {
+        <div class="spoiler-blur-bg" style="--spoiler-bg: url('@_location')"></div>
+        <div class="spoiler-overlay">
+            <span>Spoiler &mdash; click to reveal</span>
+        </div>
+    }
+    else
+    {
+        <LazyImage CssClass="attached-image"
+                   Style="@GetImageStyle()"
+                   Alt="@Attachment.FileName"
+                   Src="@_location"
+                   FallbackSrc="_content/Valour.Client/media/image-not-found.webp"
+                   RootMargin="400px 0px"
+                   data-og-src="@Attachment.Location" />
+    }
 </div>
 
 @code {
@@ -23,10 +33,17 @@
     private string GetWrapperStyle()
     {
         // No size metadata (e.g. older thread attachments): let the image
-        // render at natural size, clamped by the max constraints below
+        // render at natural size, clamped by the max constraints below. The
+        // spoiler blur/overlay are both position:absolute though, so with no
+        // size to go on they'd collapse to nothing - give them a fixed height.
         if (_width <= 0 || _height <= 0)
-            return $"max-width: min({MaxSize}px, 100%);";
+            return IsHiddenSpoiler
+                ? $"max-width: min({MaxSize}px, 100%); height: 200px;"
+                : $"max-width: min({MaxSize}px, 100%);";
 
+        // This also sizes the spoiler placeholder (see markup below) - since
+        // LazyImage isn't rendered while hidden, nothing else is competing to
+        // size the wrapper.
         if (DoAspect)
             return $"aspect-ratio: {_width} / {_height}; max-width: min({MaxSize}px, 100%); width: {_width}px";
 
@@ -51,6 +68,9 @@
     public string CustomStyle { get; set; }
     
     private string _location;
+    private bool _revealed;
+
+    private bool IsHiddenSpoiler => Attachment.IsSpoiler && !_revealed;
 
     protected override async Task OnInitializedAsync()
     {
@@ -90,8 +110,14 @@
 
     private void OnClick()
     {
+        if (IsHiddenSpoiler)
+        {
+            _revealed = true;
+            return;
+        }
+
         if (!Clickable || Attachment.Missing) return;
-        
+
         var modalParams = new AttachmentModal.ModalParams()
         {
             Attachment = Attachment,

--- a/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor.css
+++ b/Valour/Client/Components/Messages/Attachments/ImageAttachmentComponent.razor.css
@@ -1,4 +1,4 @@
-﻿.image-attachment-wrapper {
+.image-attachment-wrapper {
     margin-top: 5px;
     margin-bottom: 5px;
     border-radius: var(--radius-md);
@@ -17,4 +17,36 @@
 }
 
 .attached-image {
+}
+
+.image-attachment-wrapper.spoiler-hidden {
+    position: relative;
+    cursor: pointer;
+    overflow: hidden;
+}
+
+/* Separate blurred div rather than a filter on the real img - keeps this
+   sized off the wrapper directly instead of a child component's own image. */
+.spoiler-blur-bg {
+    position: absolute;
+    inset: -12px;
+    background-image: var(--spoiler-bg);
+    background-size: cover;
+    background-position: center;
+    filter: blur(20px);
+}
+
+.spoiler-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 8px;
+    border-radius: var(--radius-md);
+    background-color: rgba(0, 0, 0, 0.35);
+    color: white;
+    font-weight: 600;
+    pointer-events: none;
 }

--- a/Valour/Client/Components/Messages/Attachments/VideoAttachmentComponent.razor
+++ b/Valour/Client/Components/Messages/Attachments/VideoAttachmentComponent.razor
@@ -6,18 +6,34 @@
 }
 else
 {
-    <video class="video-attachment" controls loop preload="metadata" playsinline src="@_location#t=0.001" type="@Attachment.MimeType"></video>
+    <div class="video-attachment-wrapper @(IsHiddenSpoiler ? "spoiler-hidden" : "")">
+        <video class="video-attachment" controls loop preload="metadata" playsinline src="@_location#t=0.001" type="@Attachment.MimeType"></video>
+        @if (IsHiddenSpoiler)
+        {
+            <div class="spoiler-overlay" @onclick="Reveal">
+                <span>Spoiler &mdash; click to reveal</span>
+            </div>
+        }
+    </div>
 }
 
 @code {
     [Parameter]
     public string CustomStyle { get; set; }
-    
+
     private string _location;
+    private bool _revealed;
+
+    private bool IsHiddenSpoiler => Attachment.IsSpoiler && !_revealed;
 
     protected override async Task OnInitializedAsync()
     {
         _location = await Attachment.GetSignedUrl(Message.Client, Message.Node);
+    }
+
+    private void Reveal()
+    {
+        _revealed = true;
     }
 
 }

--- a/Valour/Client/Components/Messages/Attachments/VideoAttachmentComponent.razor.css
+++ b/Valour/Client/Components/Messages/Attachments/VideoAttachmentComponent.razor.css
@@ -2,3 +2,28 @@
     max-width: 100%;
     max-height: min(400px, 80vh);
 }
+
+.video-attachment-wrapper {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+}
+
+.video-attachment-wrapper.spoiler-hidden .video-attachment {
+    filter: blur(24px);
+}
+
+.spoiler-overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 8px;
+    border-radius: var(--radius-md);
+    background-color: rgba(0, 0, 0, 0.35);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+}

--- a/Valour/Client/Components/Messages/MessageComponent.razor
+++ b/Valour/Client/Components/Messages/MessageComponent.razor
@@ -707,8 +707,8 @@ else
         if (_ghost) return;
     }
 
-    // Lazy so the vast majority of messages (no spoilered embeds) don't pay for
-    // an empty set each.
+    // Lazy so the vast majority of messages (no spoilered embeds)
+    // don't pay for an empty set each.
     private HashSet<int> _revealedSpoilerAttachments;
 
     private async Task RevealSpoilerAttachment(int id)

--- a/Valour/Client/Components/Messages/MessageComponent.razor
+++ b/Valour/Client/Components/Messages/MessageComponent.razor
@@ -96,9 +96,9 @@ else
                         continue;
 
                     // Image/Video handle their own blur-and-reveal. Everything else (embeds)
-                    // just doesn't mount its component until revealed, since some of those
-                    // are third-party iframes and we don't want to ping Twitter/YouTube/etc.
-                    // just because the message rendered.
+                    // just doesn't mount its component until revealed,
+                    // since some of those are third-party iframes and we don't want
+                    // to ping Twitter/YouTube/etc. just because the message rendered.
                     var isHiddenEmbedSpoiler = attachment.IsSpoiler &&
                                                 attachment.Type != MessageAttachmentType.Image &&
                                                 attachment.Type != MessageAttachmentType.Video &&

--- a/Valour/Client/Components/Messages/MessageComponent.razor
+++ b/Valour/Client/Components/Messages/MessageComponent.razor
@@ -95,6 +95,15 @@ else
                     if (componentType is null)
                         continue;
 
+                    // Image/Video handle their own blur-and-reveal. Everything else (embeds)
+                    // just doesn't mount its component until revealed, since some of those
+                    // are third-party iframes and we don't want to ping Twitter/YouTube/etc.
+                    // just because the message rendered.
+                    var isHiddenEmbedSpoiler = attachment.IsSpoiler &&
+                                                attachment.Type != MessageAttachmentType.Image &&
+                                                attachment.Type != MessageAttachmentType.Video &&
+                                                !(_revealedSpoilerAttachments?.Contains(id) ?? false);
+
                     <div class="attachment-wrapper" @onclick="() => OnClickAttachment(id)">
                         @if (_ghost && !_isInnerReply)
                         {
@@ -103,7 +112,16 @@ else
                                 <img src="_content/Valour.Client/media/Trash-Can-Icon.svg" alt="" />
                             </button>
                         }
-                        <DynamicComponent Type="componentType" Parameters="par"></DynamicComponent>
+                        @if (isHiddenEmbedSpoiler)
+                        {
+                            <div class="embed-spoiler-placeholder" @onclick="() => RevealSpoilerAttachment(id)" @onclick:stopPropagation="true">
+                                <span>Spoiler &mdash; click to reveal embed</span>
+                            </div>
+                        }
+                        else
+                        {
+                            <DynamicComponent Type="componentType" Parameters="par"></DynamicComponent>
+                        }
                     </div>
                 }
             }
@@ -687,6 +705,18 @@ else
     public void OnClickAttachment(int id)
     {
         if (_ghost) return;
+    }
+
+    // Lazy so the vast majority of messages (no spoilered embeds) don't pay for
+    // an empty set each.
+    private HashSet<int> _revealedSpoilerAttachments;
+
+    private async Task RevealSpoilerAttachment(int id)
+    {
+        (_revealedSpoilerAttachments ??= new()).Add(id);
+        // ShouldRender() is overridden to return false below, so without an
+        // explicit ReRender() this click would just silently do nothing.
+        await ReRender();
     }
 
     public void OnRemoveAttachmentClick(int id)

--- a/Valour/Client/Components/Messages/MessageComponent.razor.css
+++ b/Valour/Client/Components/Messages/MessageComponent.razor.css
@@ -348,6 +348,20 @@
     overflow: auto;
 }
 
+.embed-spoiler-placeholder {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    min-height: 120px;
+    padding: 16px;
+    border-radius: var(--radius-md);
+    background-color: rgba(255, 255, 255, 0.08);
+    color: white;
+    font-weight: 600;
+    cursor: pointer;
+}
+
 .preview-message .reply:hover .reply-remove {
     display: block;
 }

--- a/Valour/Client/Markdig/SpoilerExtension.cs
+++ b/Valour/Client/Markdig/SpoilerExtension.cs
@@ -1,0 +1,39 @@
+using Markdig;
+using Markdig.Parsers.Inlines;
+using Markdig.Renderers;
+
+namespace Valour.Client.Markdig;
+
+/// <summary>
+/// A markdown extension for parsing ||spoiler|| text. Requires UseEmphasisExtras()
+/// (or any other extension registering EmphasisInlineParser) to already be present
+/// in the pipeline, since it hooks into that parser rather than adding a new one.
+/// </summary>
+public class SpoilerExtension : IMarkdownExtension
+{
+    public void Setup(MarkdownPipelineBuilder pipeline)
+    {
+        var emphasisParser = pipeline.InlineParsers.Find<EmphasisInlineParser>();
+        if (emphasisParser is null)
+            return;
+
+        if (!emphasisParser.HasEmphasisChar('|'))
+            emphasisParser.EmphasisDescriptors.Add(new EmphasisDescriptor('|', 2, 2, false));
+
+        emphasisParser.TryCreateEmphasisInlineList.Add((delimiterChar, delimiterCount) =>
+            delimiterChar == '|' ? new SpoilerInline() : null);
+    }
+
+    public void Setup(MarkdownPipeline pipeline, IMarkdownRenderer renderer)
+    {
+    }
+}
+
+public static class SpoilerMarkdownExtension
+{
+    public static MarkdownPipelineBuilder UseSpoilerExtension(this MarkdownPipelineBuilder pipeline)
+    {
+        pipeline.Extensions.AddIfNotAlready<SpoilerExtension>();
+        return pipeline;
+    }
+}

--- a/Valour/Client/Markdig/SpoilerInline.cs
+++ b/Valour/Client/Markdig/SpoilerInline.cs
@@ -1,0 +1,12 @@
+using Markdig.Syntax.Inlines;
+
+namespace Valour.Client.Markdig;
+
+/// <summary>
+/// A ||spoiler|| span. Reuses Markdig's built-in delimiter-run/emphasis machinery
+/// (via SpoilerExtension registering '|' as an emphasis character), so nested
+/// inline content (bold, mentions, emoji, etc.) inside a spoiler parses normally.
+/// </summary>
+public class SpoilerInline : EmphasisInline
+{
+}

--- a/Valour/Client/Markdig/SpoilerRenderer.cs
+++ b/Valour/Client/Markdig/SpoilerRenderer.cs
@@ -30,11 +30,10 @@ public class SpoilerRenderer : BlazorObjectRenderer<SpoilerInline>
     }
 
     /// <summary>
-    /// Markdig's autolink parser won't pick up a URL sitting right against a
-    /// custom emphasis delimiter, so a bare link at the start/end of a spoiler
-    /// never gets auto-linked normally. Find and link those manually here using
-    /// the same URL pattern the server uses for embeds, routed through the
-    /// normal renderer.Render path so it still gets in-app link handling.
+    /// Markdig's autolink parser won't pick up a URL sitting right against a custom emphasis delimiter,
+    /// so a bare link at the start/end of a spoiler never gets auto-linked normally. 
+    /// Find and link those manually here using the same URL pattern the server uses for embeds,
+    /// routed through the normal renderer.Render path so it still gets in-app link handling.
     /// </summary>
     private static void WriteInlineWithAutoLinks(BlazorRenderer renderer, Inline child)
     {

--- a/Valour/Client/Markdig/SpoilerRenderer.cs
+++ b/Valour/Client/Markdig/SpoilerRenderer.cs
@@ -16,9 +16,9 @@ public class SpoilerRenderer : BlazorObjectRenderer<SpoilerInline>
         renderer.AddAttribute("class", "md-spoiler", 1);
         renderer.AddAttribute("role", "button", 2);
         renderer.AddAttribute("tabindex", "0", 3);
-        // Plain inline onclick instead of a Blazor event handler - the reveal is
-        // purely visual, and this way it still works in ghost/preview renders
-        // that never wire up Blazor's event dispatch.
+        // Plain inline onclick instead of a Blazor event handler.
+        // The reveal is purely visual, and this way it still works
+        // in ghost/preview renders that never wire up Blazor's event dispatch.
         renderer.AddAttribute("onclick", "this.classList.toggle('revealed')", 4);
 
         foreach (var child in obj)

--- a/Valour/Client/Markdig/SpoilerRenderer.cs
+++ b/Valour/Client/Markdig/SpoilerRenderer.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+using Markdig.Blazor;
+using Markdig.Syntax.Inlines;
+using Valour.Shared.Cdn;
+
+namespace Valour.Client.Markdig;
+
+public class SpoilerRenderer : BlazorObjectRenderer<SpoilerInline>
+{
+    protected override void Write(BlazorRenderer renderer, SpoilerInline obj)
+    {
+        if (renderer == null) throw new ArgumentNullException(nameof(renderer));
+        if (obj == null) throw new ArgumentNullException(nameof(obj));
+
+        renderer.OpenElement("span", 0);
+        renderer.AddAttribute("class", "md-spoiler", 1);
+        renderer.AddAttribute("role", "button", 2);
+        renderer.AddAttribute("tabindex", "0", 3);
+        // Plain inline onclick instead of a Blazor event handler - the reveal is
+        // purely visual, and this way it still works in ghost/preview renders
+        // that never wire up Blazor's event dispatch.
+        renderer.AddAttribute("onclick", "this.classList.toggle('revealed')", 4);
+
+        foreach (var child in obj)
+        {
+            WriteInlineWithAutoLinks(renderer, child);
+        }
+
+        renderer.CloseElement();
+    }
+
+    /// <summary>
+    /// Markdig's autolink parser won't pick up a URL sitting right against a
+    /// custom emphasis delimiter, so a bare link at the start/end of a spoiler
+    /// never gets auto-linked normally. Find and link those manually here using
+    /// the same URL pattern the server uses for embeds, routed through the
+    /// normal renderer.Render path so it still gets in-app link handling.
+    /// </summary>
+    private static void WriteInlineWithAutoLinks(BlazorRenderer renderer, Inline child)
+    {
+        if (child is not LiteralInline literal)
+        {
+            renderer.Render(child);
+            return;
+        }
+
+        var text = literal.Content.ToString();
+        var matches = CdnUtils.UrlRegex.Matches(text);
+        if (matches.Count == 0)
+        {
+            renderer.Render(child);
+            return;
+        }
+
+        var cursor = 0;
+        foreach (Match match in matches)
+        {
+            if (match.Index > cursor)
+                renderer.WriteText(text.Substring(cursor, match.Index - cursor), 0);
+
+            var link = new LinkInline
+            {
+                Url = match.Value,
+                IsAutoLink = true,
+            };
+            link.AppendChild(new LiteralInline(match.Value));
+            renderer.Render(link);
+
+            cursor = match.Index + match.Length;
+        }
+
+        if (cursor < text.Length)
+            renderer.WriteText(text.Substring(cursor), 0);
+    }
+}

--- a/Valour/Client/Messages/Rendering/MarkdownManager.cs
+++ b/Valour/Client/Messages/Rendering/MarkdownManager.cs
@@ -51,9 +51,9 @@ public static class MarkdownManager
         Renderer.ObjectRenderers.Add(new ValourEmojiRenderer());
 
         // Must be inserted ahead of the package's built-in EmphasisInlineRenderer -
-        // SpoilerInline derives from EmphasisInline to reuse its delimiter-run
-        // parsing, but that also means the built-in renderer matches it and would
-        // render the spoiler's contents unwrapped, with no span/blur at all.
+        // SpoilerInline derives from EmphasisInline to reuse its delimiter-run parsing,
+        // but that also means the built-in renderer matches it and would render
+        // the spoiler's contents unwrapped, with no span/blur at all.
         Renderer.ObjectRenderers.Insert(0, new SpoilerRenderer());
 
         // Must be inserted ahead of the package's built-in LinkInlineRenderer so

--- a/Valour/Client/Messages/Rendering/MarkdownManager.cs
+++ b/Valour/Client/Messages/Rendering/MarkdownManager.cs
@@ -39,7 +39,7 @@ public static class MarkdownManager
             .UseGridTables()
             .UseListExtras()
             .UseEmphasisExtras()
-            //.UseEmojiAndSmiley(DevicePreferences.AutoEmoji)
+            .UseSpoilerExtension()
             .UseMentionExtension()
             .UseStockExtension()
             .UseValourEmojiExtension(DevicePreferences.AutoEmoji)
@@ -49,6 +49,12 @@ public static class MarkdownManager
         Renderer.ObjectRenderers.Add(new MentionRenderer());
         Renderer.ObjectRenderers.Add(new StockRenderer());
         Renderer.ObjectRenderers.Add(new ValourEmojiRenderer());
+
+        // Must be inserted ahead of the package's built-in EmphasisInlineRenderer -
+        // SpoilerInline derives from EmphasisInline to reuse its delimiter-run
+        // parsing, but that also means the built-in renderer matches it and would
+        // render the spoiler's contents unwrapped, with no span/blur at all.
+        Renderer.ObjectRenderers.Insert(0, new SpoilerRenderer());
 
         // Must be inserted ahead of the package's built-in LinkInlineRenderer so
         // Valour links get in-app navigation instead of opening a new tab.

--- a/Valour/Client/wwwroot/css/globals.css
+++ b/Valour/Client/wwwroot/css/globals.css
@@ -996,6 +996,29 @@ blockquote {
     background-color: rgba(255, 255, 255, 0.01);
 }
 
+.md-spoiler {
+    border-radius: 3px;
+    cursor: pointer;
+    background-color: rgba(255, 255, 255, 0.08);
+}
+
+.md-spoiler:not(.revealed) {
+    filter: blur(5px);
+    user-select: none;
+}
+
+/* Blur alone is just visual - a link inside would still be clickable through
+   it otherwise. Only disables pointer-events on children, so the span's own
+   onclick to reveal still works. */
+.md-spoiler:not(.revealed) * {
+    pointer-events: none;
+}
+
+.md-spoiler.revealed {
+    cursor: text;
+    background-color: transparent;
+}
+
 /* Fix for safari */
 [contenteditable] {
     -webkit-user-select: text;

--- a/Valour/Database/MessageAttachment.cs
+++ b/Valour/Database/MessageAttachment.cs
@@ -43,6 +43,11 @@ public class MessageAttachment
     /// </summary>
     public string ReportedSha256 { get; set; }
 
+    /// <summary>
+    /// When true, the client blurs this attachment until the user clicks to reveal it.
+    /// </summary>
+    public bool IsSpoiler { get; set; }
+
     public static void SetupDbModel(ModelBuilder builder)
     {
         builder.Entity<MessageAttachment>(e =>
@@ -108,6 +113,11 @@ public class MessageAttachment
 
             e.Property(x => x.ReportedSha256)
                 .HasColumnName("reported_sha256");
+
+            e.Property(x => x.IsSpoiler)
+                .HasColumnName("is_spoiler")
+                .HasDefaultValue(false)
+                .IsRequired();
 
             e.HasOne(x => x.Message)
                 .WithMany(x => x.Attachments)

--- a/Valour/Database/Migrations/20260802003740_MessageAttachmentIsSpoiler.Designer.cs
+++ b/Valour/Database/Migrations/20260802003740_MessageAttachmentIsSpoiler.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Valour.Database.Context;
 namespace Valour.Database.Migrations
 {
     [DbContext(typeof(ValourDb))]
-    partial class ValourDbModelSnapshot : ModelSnapshot
+    [Migration("20260802003740_MessageAttachmentIsSpoiler")]
+    partial class MessageAttachmentIsSpoiler
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Valour/Database/Migrations/20260802003740_MessageAttachmentIsSpoiler.cs
+++ b/Valour/Database/Migrations/20260802003740_MessageAttachmentIsSpoiler.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Valour.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class MessageAttachmentIsSpoiler : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_spoiler",
+                table: "message_attachments",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "is_spoiler",
+                table: "message_attachments");
+        }
+    }
+}

--- a/Valour/Sdk/Models/MessageAttachment.cs
+++ b/Valour/Sdk/Models/MessageAttachment.cs
@@ -64,6 +64,12 @@ public class MessageAttachment : ISharedMessageAttachment
     /// </summary>
     public string ReportedSha256 { get; set; }
 
+    /// <summary>
+    /// True if the uploader marked this attachment as a spoiler - the client
+    /// blurs it until clicked.
+    /// </summary>
+    public bool IsSpoiler { get; set; }
+
     public MessageAttachment()
     {
     }

--- a/Valour/Server/Cdn/ProxyHandler.cs
+++ b/Valour/Server/Cdn/ProxyHandler.cs
@@ -78,6 +78,7 @@ public class ProxyHandler
             if (attachment != null)
             {
                 attachment.Inline = true;
+                attachment.IsSpoiler = IsInsideSpoiler(url, match.Index);
 
                 if (attachments is null)
                     attachments = new();
@@ -87,6 +88,31 @@ public class ProxyHandler
         }
 
         return attachments;
+    }
+
+    /// <summary>
+    /// True if the given index falls inside a ||spoiler|| span, so an embed
+    /// generated from a URL there can inherit the spoiler too. Just counts
+    /// '||' pairs up to that point rather than running a full Markdig parse.
+    /// </summary>
+    private static bool IsInsideSpoiler(string url, int index)
+    {
+        var openSpans = 0;
+        var i = 0;
+        while (i < index)
+        {
+            if (url[i] == '|' && i + 1 < url.Length && url[i + 1] == '|')
+            {
+                openSpans++;
+                i += 2;
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return openSpans % 2 == 1;
     }
 
     /// <summary>

--- a/Valour/Server/Mapping/MessageAttachmentMapper.cs
+++ b/Valour/Server/Mapping/MessageAttachmentMapper.cs
@@ -41,7 +41,8 @@ public static class MessageAttachmentMapper
             Data = attachment.Data,
             OpenGraph = openGraph,
             PlanetHosted = attachment.PlanetHosted,
-            ReportedSha256 = attachment.ReportedSha256
+            ReportedSha256 = attachment.ReportedSha256,
+            IsSpoiler = attachment.IsSpoiler
         };
     }
 
@@ -70,7 +71,8 @@ public static class MessageAttachmentMapper
             Data = attachment.Data,
             OpenGraphData = attachment.OpenGraph is null ? null : JsonSerializer.Serialize(attachment.OpenGraph),
             PlanetHosted = attachment.PlanetHosted,
-            ReportedSha256 = attachment.ReportedSha256
+            ReportedSha256 = attachment.ReportedSha256,
+            IsSpoiler = attachment.IsSpoiler
         };
     }
 }


### PR DESCRIPTION
## Summary
Adds  `||spoiler||` markdown for message text, plus a "Mark as spoiler" option when uploading an image or video. Spoilered images/videos render blurred with a click-to-reveal overlay, and link previews (Twitter cards, YouTube, etc.) generated from a URL inside a spoiler now inherit the spoiler too, so they don't leak the content before it's revealed.

## Changes
- New `||spoiler||` inline markdown extension (hooks into Markdig's emphasis parser, so nested formatting/mentions/emoji inside a spoiler still work)
- Blur + reveal-on-click UI for spoilered images, videos, and text
- Spoilered links produce a spoilered embed instead of an immediately visible one
- New `is_spoiler` column on `message_attachments` (migration included)
- Spoiler toggle checkbox added to the image/video upload modal

## Test plan
- [x] `||text||` renders blurred and reveals on click, including nested bold/mentions/emoji
- [x] Bare URL inside `||...||` still becomes a working link
- [x] A link inside a spoiler isn't clickable until revealed
- [x] Uploading an image/video with "Mark as spoiler" checked blurs it in chat until clicked
- [x] A spoilered link's auto-generated embed is also hidden until revealed
- [x] Migration applies cleanly to an existing database

## Images & Videos

<details>
<summary>Spoiler Text</summary>

https://github.com/user-attachments/assets/5ab6c549-150a-4c9f-bc63-c7bfe2db3cba

</details>

<details>
<summary>Spoiler Attachment</summary>

https://github.com/user-attachments/assets/4f8c6550-28d1-49ca-88f9-f2df321b3c38

</details>

<details>
<summary>Spoiler Embeds</summary>

https://github.com/user-attachments/assets/79890866-38b2-4eb1-abf9-e751179f4105

</details>