### PR TITLE
Show online status ring on DM tab icons

### DIFF
--- a/Valour/Client/Components/DockWindows/WindowComponent.razor
+++ b/Valour/Client/Components/DockWindows/WindowComponent.razor
@@ -25,7 +25,16 @@
                 @oncontextpress:stopPropagation="true"
                 @oncontextpress="@OnTabContextMenu">
                 <div class="tab-info">
-                    <img alt="tab icon" class="tab-icon @(IsPlanetTab ? "circle" : "")" src="@Icon"/>
+                    @if (IconUser is not null)
+                    {
+                        <div class="tab-icon-avatar">
+                            <UserAvatar User="@IconUser" Size="22" ShowState="true"/>
+                        </div>
+                    }
+                    else
+                    {
+                        <img alt="tab icon" class="tab-icon @(IsPlanetTab ? "circle" : "")" src="@Icon"/>
+                    }
                     <span class="tab-title">@Title</span>
                 </div>
                 <div class="tab-buttons"
@@ -177,7 +186,8 @@
     }
 
     private string Icon => WindowTab.Content?.Icon ?? ThreadsWindowComponent.DefaultContent.Icon;
-    
+    private User IconUser => WindowTab.Content?.IconUser;
+
     /// <summary>
     /// Planet tabs show circular icons; user/app tabs show rounded squares
     /// </summary>

--- a/Valour/Client/Components/DockWindows/WindowComponent.razor.css
+++ b/Valour/Client/Components/DockWindows/WindowComponent.razor.css
@@ -264,6 +264,18 @@
     border-radius: var(--radius-full);
 }
 
+.tab-icon-avatar {
+    margin-right: 4px;
+    flex-shrink: 0;
+    opacity: 0.8;
+    transition: opacity var(--duration-fast) var(--ease-standard);
+}
+
+.tab:hover .tab-icon-avatar,
+.active .tab .tab-icon-avatar {
+    opacity: 1;
+}
+
 .tab:hover .tab-icon,
 .active .tab .tab-icon {
     opacity: 1;

--- a/Valour/Client/Components/DockWindows/WindowSaveLoadAdapter.cs
+++ b/Valour/Client/Components/DockWindows/WindowSaveLoadAdapter.cs
@@ -13,6 +13,13 @@ public class WindowContentState
 {
     public string Title { get; set; }
     public string Icon { get; set; }
+
+    /// <summary>
+    /// Id of the DM tab's IconUser, if it had one - so the status ring can be
+    /// restored on reload without waiting for the channel's own data to load.
+    /// </summary>
+    public long? IconUserId { get; set; }
+
     public long? PlanetId { get; set; }
     public bool AutoScroll { get; set; }
     
@@ -189,6 +196,7 @@ public class WindowSaveLoadAdapter
                     {
                         Title = tab.Content.Title,
                         Icon = tab.Content.Icon,
+                        IconUserId = tab.Content.IconUser?.Id,
                         PlanetId = tab.Content.PlanetId,
                         AutoScroll = tab.Content.AutoScroll,
                         ComponentType = tab.Content.ComponentType.FullName,
@@ -321,6 +329,9 @@ public class WindowSaveLoadAdapter
         content.Icon = state.ContentState.Icon;
         content.PlanetId = state.ContentState.PlanetId;
         content.AutoScroll = state.ContentState.AutoScroll;
+
+        if (state.ContentState.IconUserId is not null)
+            content.IconUser = await _client.UserService.FetchUserAsync(state.ContentState.IconUserId.Value);
 
         // Does this content type carry data? (WindowContent<TWindow, TData>)
         var importMethod = content.GetType().GetMethod("ImportData");

--- a/Valour/Client/Components/DockWindows/WindowSaveLoadAdapter.cs
+++ b/Valour/Client/Components/DockWindows/WindowSaveLoadAdapter.cs
@@ -19,7 +19,6 @@ public class WindowContentState
     /// restored on reload without waiting for the channel's own data to load.
     /// </summary>
     public long? IconUserId { get; set; }
-
     public long? PlanetId { get; set; }
     public bool AutoScroll { get; set; }
     

--- a/Valour/Client/Components/DockWindows/WindowTab.cs
+++ b/Valour/Client/Components/DockWindows/WindowTab.cs
@@ -17,7 +17,6 @@ public abstract class WindowContent
     /// UserAvatar (with online-state ring) instead of a plain static Icon url.
     /// </summary>
     public User IconUser { get; set; }
-
     public long? PlanetId { get; set; }
     public bool AutoScroll { get; set; }
     

--- a/Valour/Client/Components/DockWindows/WindowTab.cs
+++ b/Valour/Client/Components/DockWindows/WindowTab.cs
@@ -11,6 +11,13 @@ public abstract class WindowContent
     public string Id { get; private set; } = Guid.NewGuid().ToString();
     public string Title { get; set; }
     public string Icon { get; set; }
+
+    /// <summary>
+    /// Optional - set for DM tabs so the tab icon can render as a live
+    /// UserAvatar (with online-state ring) instead of a plain static Icon url.
+    /// </summary>
+    public User IconUser { get; set; }
+
     public long? PlanetId { get; set; }
     public bool AutoScroll { get; set; }
     

--- a/Valour/Client/Components/Users/UserAvatar.razor.css
+++ b/Valour/Client/Components/Users/UserAvatar.razor.css
@@ -20,23 +20,23 @@
 }
 
 .user-avatar.with-state .user-avatar-img {
-    width: calc(100% - 8px);
-    height: calc(100% - 8px);
-    margin: 4px;
-    border-radius: calc(var(--radius-md) - 2px);
+    width: calc(100% - 4px);
+    height: calc(100% - 4px);
+    margin: 2px;
+    border-radius: calc(var(--radius-md) - 1px);
 }
 
 .user-avatar.with-state .user-avatar-img::after {
-    border-radius: calc(var(--radius-md) + 2px);
+    border-radius: calc(var(--radius-md) + 1px);
 }
 
 .user-avatar-img::after {
     content: '';
     position: absolute;
-    inset: -4px;
-    border-radius: calc(var(--radius-md) + 3px);
+    inset: -2px;
+    border-radius: calc(var(--radius-md) + 1px);
     border: 1px solid var(--state-ring, transparent);
-    box-shadow: 0 0 8px color-mix(in srgb, var(--state-ring, transparent) 45%, transparent);
+    box-shadow: 0 0 6px color-mix(in srgb, var(--state-ring, transparent) 45%, transparent);
     pointer-events: none;
     opacity: 0.8;
 }
@@ -78,7 +78,7 @@
 
 /* When both rings show, keep the outer gradient ring concentric with the inner state ring */
 .user-avatar.with-state.unread::after {
-    border-radius: calc(var(--radius-md) + 6px);
+    border-radius: calc(var(--radius-md) + 5px);
 }
 
 .user-avatar-badges {

--- a/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
+++ b/Valour/Client/Components/Windows/ChannelWindows/ChatWindowComponent.razor
@@ -1556,9 +1556,12 @@
             await planet.EnsureReadyAsync();
         }
 
+        var dmUser = await channel.GetDmUserAsync();
+
         return new()
         {
-            Icon = await channel.GetIconAsync(),
+            Icon = await channel.GetIconAsync(dmUser),
+            IconUser = dmUser,
             Title = await channel.GetTitleAsync(),
             PlanetId = channel.PlanetId,
             Data = channel

--- a/Valour/Sdk/Models/Channel.cs
+++ b/Valour/Sdk/Models/Channel.cs
@@ -686,32 +686,34 @@ public class Channel : ClientPlanetModel<Channel, long>, ISharedChannel
         return "A " + GetHumanReadableName() + " channel";
     }
 
-    public async Task<string> GetIconAsync()
+    /// <summary>
+    /// For a DM channel, the user the icon/avatar should represent - the other
+    /// member, or yourself for a self-DM. Null for planet channels or if member
+    /// data hasn't loaded yet.
+    /// </summary>
+    public async Task<User> GetDmUserAsync()
     {
-        var result = "./_content/Valour.Client/media/logo/logo-128.webp";
-        
+        if (PlanetId is not null || Members is null)
+            return null;
+
+        var otherId = Members.FirstOrDefault(x => x.UserId != Client.Me.Id)?.UserId;
+        if (otherId is null)
+            return Client.Me;
+
+        return await Client.UserService.FetchUserAsync(otherId.Value);
+    }
+
+    /// <summary>
+    /// Pass an already-fetched dmUser (e.g. from GetDmUserAsync) if you have one
+    /// on hand, so this doesn't look it up a second time.
+    /// </summary>
+    public async Task<string> GetIconAsync(User dmUser = null)
+    {
         if (PlanetId is not null)
-        {
-            result = Planet.GetIconUrl(IconFormat.Webp64);
-        }
-        else
-        {
-            // Missing member data is not the same as a self-DM
-            if (Members is null)
-                return result;
+            return Planet.GetIconUrl(IconFormat.Webp64);
 
-            var others = Members.Where(x => x.UserId != Client.Me.Id).ToList();
-            if (!others.Any())
-            {
-                return Client.Me.GetAvatar();
-            }
-
-            var other = await Client.UserService.FetchUserAsync(others.First().UserId);
-            if (other is not null)
-                result = other.GetAvatar();
-        }
-
-        return result;
+        dmUser ??= await GetDmUserAsync();
+        return dmUser?.GetAvatar() ?? "./_content/Valour.Client/media/logo/logo-128.webp";
     }
 
     public async Task<string> GetTitleAsync()


### PR DESCRIPTION
## Summary
This came from an idea in #1446 — I thought it'd be a nice touch, so here's my take on how to build it. DM tabs at the top now show the other user's live avatar (with the same online/away/DND status ring used in the sidebar and message list) instead of a static icon, so you can tell someone's status at a glance without opening the chat.

## Changes
- `Channel.GetDmUserAsync()` resolves the other member (or yourself, for a self-DM) of a DM channel
- `WindowContent` can carry an optional live `IconUser`; when set, the tab strip renders a `UserAvatar` with its status ring instead of the plain icon image
- The status ring persists across a page reload (saved/restored alongside the rest of a tab's layout state), not just for tabs opened in the current session
- Tightened the status ring's gap on `UserAvatar` generally — it read as a bit too spaced out from the picture at any size, not just in the tab strip

## Images

**Before:**
<img width="1037" height="45" alt="image" src="https://github.com/user-attachments/assets/d64969d0-fe81-4c6c-91bf-c9996a5a6a4b" />


**After:**
<img width="1040" height="41" alt="image" src="https://github.com/user-attachments/assets/3e8c8dca-0a69-4e04-9437-55602b6bca52" />
