### PR TITLE
Let a planet's vanity URL double as an invite link

### DIFF
--- a/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetInvitesComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Planets/Edit/EditPlanetInvitesComponent.razor
@@ -30,6 +30,38 @@
             <ResultLabel Result="@publicResult" />
         </div>
 
+        @if (publicValue)
+        {
+            <div class="toggle-item">
+                <div class="toggle-header">
+                    <span class="toggle-title">Use Vanity URL as Invite</span>
+                    <label class="switch">
+                        <input type="checkbox" @oninput="OnCheckVanityInvite" checked="@vanityInviteValue" disabled="@string.IsNullOrWhiteSpace(Planet.Vanity)" />
+                        <span class="slider round"></span>
+                    </label>
+                </div>
+                @if (string.IsNullOrWhiteSpace(Planet.Vanity))
+                {
+                    <p class="toggle-description">
+                        <span class="danger-note">Claim a Vanity URL in the Info tab first to use it as an invite link.</span>
+                    </p>
+                }
+                else if (!vanityInviteValue)
+                {
+                    <p class="toggle-description">
+                        <span>Let <strong>@Planet.Vanity</strong> be used as an invite link too, alongside your regular invite codes.</span>
+                    </p>
+                }
+                <ResultLabel Result="@vanityInviteResult" />
+                @if (vanityInviteValue)
+                {
+                    <button class="v-btn small mt-2" title="Copy vanity invite link" @onclick="CopyVanityInviteLink">
+                        <i class="bi bi-clipboard"></i> Copy Vanity Invite Link
+                    </button>
+                }
+            </div>
+        }
+
         <div class="toggle-item">
             <div class="toggle-header">
                 <span class="toggle-title">Discoverable</span>
@@ -76,7 +108,7 @@
             Invite Links
         </h3>
 
-        @if (!Planet.Invites.Any())
+        @if (!Planet.Invites.Any() && !HasVanityInvite)
         {
             <div class="empty-state">
                 <i class="bi bi-envelope"></i>
@@ -86,6 +118,27 @@
         else
         {
             <div class="invite-list">
+                @if (HasVanityInvite)
+                {
+                    <div class="invite-card">
+                        <div class="invite-info">
+                            <span class="invite-code" title="@Planet.Vanity">@Planet.Vanity</span>
+                            <div class="invite-meta">
+                                <span>Vanity URL</span>
+                                <span class="separator">·</span>
+                                <span>Never expires</span>
+                            </div>
+                        </div>
+                        <div class="invite-actions">
+                            <button class="v-btn small" title="Copy invite link" @onclick="CopyVanityInviteLink">
+                                <i class="bi bi-clipboard"></i> Copy
+                            </button>
+                            <button class="v-btn small danger" title="Turn off the Use Vanity URL as Invite toggle" @onclick="DisableVanityInvite">
+                                <i class="bi bi-trash"></i>
+                            </button>
+                        </div>
+                    </div>
+                }
                 @foreach (var invite in Planet.Invites)
                 {
                     <div class="invite-card">
@@ -120,6 +173,10 @@
 
     private ITaskResult publicResult;
 
+    public bool vanityInviteValue;
+
+    private ITaskResult vanityInviteResult;
+
     public bool discoverableValue;
 
     private ITaskResult discoverableResult;
@@ -131,6 +188,7 @@
     protected override async Task OnInitializedAsync()
     {
         publicValue = Planet.Public;
+        vanityInviteValue = Planet.VanityInviteEnabled;
         discoverableValue = Planet.Discoverable;
         nsfwValue = Planet.Nsfw;
         Planet.Invites.Changed += OnPlanetInvitesChange;
@@ -147,6 +205,8 @@
         InvokeAsync(StateHasChanged);
     }
 
+    private bool HasVanityInvite => vanityInviteValue && !string.IsNullOrWhiteSpace(Planet.Vanity);
+
     public async Task OnCheckPublic()
     {
         publicValue = !publicValue;
@@ -160,6 +220,27 @@
         }
 
         StateHasChanged();
+    }
+
+    public async Task OnCheckVanityInvite()
+    {
+        await SetVanityInviteAsync(!vanityInviteValue);
+        StateHasChanged();
+    }
+
+    private async Task<bool> SetVanityInviteAsync(bool enabled)
+    {
+        vanityInviteValue = enabled;
+
+        Planet.VanityInviteEnabled = enabled;
+        vanityInviteResult = await Planet.UpdateAsync();
+
+        if (!vanityInviteResult.Success)
+        {
+            vanityInviteValue = Planet.VanityInviteEnabled;
+        }
+
+        return vanityInviteResult.Success;
     }
 
     public async Task OnCheckDiscoverable()
@@ -197,6 +278,28 @@
         var link = ShareUtils.GetInviteShareUrl(NavManager, invite.Id);
         await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", link);
         ToastContainer.Instance.AddToast(new ToastData("Copied!", "Invite link copied to clipboard", ToastProgressState.Success));
+    }
+
+    private string GetVanityInviteLink() => ShareUtils.GetInviteShareUrl(NavManager, Planet.Vanity);
+
+    private async Task CopyVanityInviteLink()
+    {
+        await JsRuntime.InvokeVoidAsync("clipboardCopy.copyText", GetVanityInviteLink());
+        ToastContainer.Instance.AddToast(new ToastData("Copied!", "Invite link copied to clipboard", ToastProgressState.Success));
+    }
+
+    private async Task DisableVanityInvite()
+    {
+        var success = await SetVanityInviteAsync(false);
+        StateHasChanged();
+
+        if (!success)
+        {
+            ToastContainer.Instance.AddToast(new ToastData("Error", vanityInviteResult.Message, ToastProgressState.Failure));
+            return;
+        }
+
+        ToastContainer.Instance.AddToast(new ToastData("Disabled", "The vanity URL is no longer usable as an invite link", ToastProgressState.Success));
     }
 
     private async Task CopyDiscoverableLink()

--- a/Valour/Database/Migrations/20260802021200_PlanetVanityInviteEnabled.Designer.cs
+++ b/Valour/Database/Migrations/20260802021200_PlanetVanityInviteEnabled.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -13,9 +14,11 @@ using Valour.Database.Context;
 namespace Valour.Database.Migrations
 {
     [DbContext(typeof(ValourDb))]
-    partial class ValourDbModelSnapshot : ModelSnapshot
+    [Migration("20260802021200_PlanetVanityInviteEnabled")]
+    partial class PlanetVanityInviteEnabled
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Valour/Database/Migrations/20260802021200_PlanetVanityInviteEnabled.cs
+++ b/Valour/Database/Migrations/20260802021200_PlanetVanityInviteEnabled.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Valour.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class PlanetVanityInviteEnabled : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "vanity_invite_enabled",
+                table: "planets",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "vanity_invite_enabled",
+                table: "planets");
+        }
+    }
+}

--- a/Valour/Database/Planet.cs
+++ b/Valour/Database/Planet.cs
@@ -176,9 +176,9 @@ public class Planet : ISharedPlanet
     public string Vanity { get; set; }
 
     /// <summary>
-    /// True when the planet's vanity name also works as a permanent invite
-    /// link (/i/{vanity}). Only takes effect while Public and Vanity are both
-    /// set - see PlanetService.UpdateAsync and ResolveVanityInviteAsync.
+    /// True when the planet's vanity name also works as a permanent invite link (/i/{vanity}).
+    /// Only takes effect while Public and Vanity are both set.
+    /// See <cref>PlanetService.UpdateAsync</cref> and <cref>ResolveVanityInviteAsync</cref>.
     /// </summary>
     public bool VanityInviteEnabled { get; set; }
 

--- a/Valour/Database/Planet.cs
+++ b/Valour/Database/Planet.cs
@@ -176,6 +176,13 @@ public class Planet : ISharedPlanet
     public string Vanity { get; set; }
 
     /// <summary>
+    /// True when the planet's vanity name also works as a permanent invite
+    /// link (/i/{vanity}). Only takes effect while Public and Vanity are both
+    /// set - see PlanetService.UpdateAsync and ResolveVanityInviteAsync.
+    /// </summary>
+    public bool VanityInviteEnabled { get; set; }
+
+    /// <summary>
     /// True when this planet stores media on its own infrastructure
     /// (bring-your-own-storage). Surfaces the "self-hosted media" warning
     /// and icon to users, including pre-join. Mapped fluently in SetupDbModel.
@@ -240,6 +247,11 @@ public class Planet : ISharedPlanet
             e.HasIndex(x => x.Vanity)
                 .IsUnique()
                 .HasFilter("vanity IS NOT NULL");
+
+            e.Property(x => x.VanityInviteEnabled)
+                .HasColumnName("vanity_invite_enabled")
+                .HasDefaultValue(false)
+                .IsRequired();
         });
     }
 }

--- a/Valour/Sdk/Models/Planet.cs
+++ b/Valour/Sdk/Models/Planet.cs
@@ -290,6 +290,11 @@ public class Planet : ClientModel<Planet, long>, ISharedPlanet, IDisposable
     public string Vanity { get; set; }
 
     /// <summary>
+    /// True when the planet's vanity name also works as a permanent invite link
+    /// </summary>
+    public bool VanityInviteEnabled { get; set; }
+
+    /// <summary>
     /// Owner-chosen default cadence for channel activity notifications
     /// </summary>
     public ChannelActivityCadence ActivityNotificationCadence { get; set; } = ChannelActivityCadence.Standard;

--- a/Valour/Server/Mapping/PlanetMapper.cs
+++ b/Valour/Server/Mapping/PlanetMapper.cs
@@ -36,6 +36,7 @@ public static class PlanetMapper
             PublicWiki = planet.PublicWiki,
             EnableCalendar = planet.EnableCalendar,
             Vanity = planet.Vanity,
+            VanityInviteEnabled = planet.VanityInviteEnabled,
             ActivityNotificationCadence = planet.ActivityNotificationCadence,
             Tags = planet.Tags?.Select(x => x.ToModel()).ToList() ?? new ()
         };
@@ -69,6 +70,7 @@ public static class PlanetMapper
         dbPlanet.PublicWiki = planet.PublicWiki;
         dbPlanet.EnableCalendar = planet.EnableCalendar;
         dbPlanet.ActivityNotificationCadence = planet.ActivityNotificationCadence;
+        dbPlanet.VanityInviteEnabled = planet.VanityInviteEnabled;
         // Vanity is intentionally NOT copied here: it is set exclusively by
         // the docs vanity endpoint so a stale planet update can never clobber
         // or claim a vanity name.

--- a/Valour/Server/Models/Planet.cs
+++ b/Valour/Server/Models/Planet.cs
@@ -117,6 +117,11 @@ public class Planet : ServerModel<long>, ISharedPlanet
     public string Vanity { get; set; }
 
     /// <summary>
+    /// True when the planet's vanity name also works as a permanent invite link
+    /// </summary>
+    public bool VanityInviteEnabled { get; set; }
+
+    /// <summary>
     /// Owner-chosen default cadence for channel activity notifications
     /// </summary>
     public ChannelActivityCadence ActivityNotificationCadence { get; set; } = ChannelActivityCadence.Standard;

--- a/Valour/Server/Services/PlanetInviteService.cs
+++ b/Valour/Server/Services/PlanetInviteService.cs
@@ -149,8 +149,8 @@ public class PlanetInviteService
         }
         else
         {
-            // Not a real invite code - a planet may have opted its vanity
-            // name in as a standing invite link, so check for that too.
+            // Not a real invite code - a planet may have opted its
+            // vanity name in as a standing invite link, so check for that too.
             var vanityPlanetId = await _planetService.ResolveVanityInviteAsync(inviteCode);
             if (vanityPlanetId is null)
                 return new TaskResult<ISharedPlanetListInfo>(false, "Invite not found.");

--- a/Valour/Server/Services/PlanetInviteService.cs
+++ b/Valour/Server/Services/PlanetInviteService.cs
@@ -137,15 +137,28 @@ public class PlanetInviteService
     {
         var invite = await _db.PlanetInvites.AsNoTracking()
             .FirstOrDefaultAsync(x => x.Id == inviteCode);
-        
-        if (invite is null)
-            return new TaskResult<ISharedPlanetListInfo>(false, "Invite not found.");
-        
-        // Check if invite is expired
-        if (invite.TimeExpires is not null && invite.TimeExpires < DateTime.UtcNow)
-            return new TaskResult<ISharedPlanetListInfo>(false, "Invite has expired.");
-        
-        var planetInfo = await _planetService.GetPlanetInfoAsync(invite.PlanetId);
+
+        long planetId;
+
+        if (invite is not null)
+        {
+            if (invite.TimeExpires is not null && invite.TimeExpires < DateTime.UtcNow)
+                return new TaskResult<ISharedPlanetListInfo>(false, "Invite has expired.");
+
+            planetId = invite.PlanetId;
+        }
+        else
+        {
+            // Not a real invite code - a planet may have opted its vanity
+            // name in as a standing invite link, so check for that too.
+            var vanityPlanetId = await _planetService.ResolveVanityInviteAsync(inviteCode);
+            if (vanityPlanetId is null)
+                return new TaskResult<ISharedPlanetListInfo>(false, "Invite not found.");
+
+            planetId = vanityPlanetId.Value;
+        }
+
+        var planetInfo = await _planetService.GetPlanetInfoAsync(planetId);
 
         if (planetInfo is null)
         {

--- a/Valour/Server/Services/PlanetService.cs
+++ b/Valour/Server/Services/PlanetService.cs
@@ -720,6 +720,15 @@ public class PlanetService
         if (old.LockedForMigration)
             return new TaskResult<Planet>(false, MigrationLock.Message);
 
+        if (planet.VanityInviteEnabled && !old.VanityInviteEnabled)
+        {
+            if (string.IsNullOrWhiteSpace(old.Vanity))
+                return new TaskResult<Planet>(false, "Set a vanity URL before using it as an invite link.");
+
+            if (!planet.Public)
+                return new TaskResult<Planet>(false, "Invites must be enabled to use the vanity URL as an invite link.");
+        }
+
         await using var tran = await _db.Database.BeginTransactionAsync();
         
         try
@@ -881,6 +890,8 @@ public class PlanetService
         if (string.IsNullOrWhiteSpace(name))
         {
             dbPlanet.Vanity = null;
+            // No vanity left to invite through, so don't leave this dangling.
+            dbPlanet.VanityInviteEnabled = false;
         }
         else
         {
@@ -922,6 +933,24 @@ public class PlanetService
 
         var planet = await _db.Planets.AsNoTracking()
             .FirstOrDefaultAsync(x => x.Vanity == name);
+
+        return planet?.Id;
+    }
+
+    /// <summary>
+    /// Like ResolveVanityAsync, but only matches planets that have opted
+    /// their vanity name in as an invite link. Used to let /i/{code} accept
+    /// a vanity name as well as a real invite code.
+    /// </summary>
+    public async Task<long?> ResolveVanityInviteAsync(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            return null;
+
+        name = name.Trim().ToLowerInvariant();
+
+        var planet = await _db.Planets.AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Vanity == name && x.VanityInviteEnabled);
 
         return planet?.Id;
     }

--- a/Valour/Shared/Models/ISharedPlanet.cs
+++ b/Valour/Shared/Models/ISharedPlanet.cs
@@ -144,8 +144,7 @@ public interface ISharedPlanet : ISharedModel<long>
     /// <summary>
     /// True when the planet's vanity name also works as a permanent invite
     /// link (/i/{vanity}), letting a memorable name double as a share link
-    /// instead of a random invite code. Only takes effect while Public and
-    /// Vanity are both set.
+    /// instead of a random invite code. Only takes effect while Public and Vanity are both set.
     /// </summary>
     bool VanityInviteEnabled { get; set; }
 

--- a/Valour/Shared/Models/ISharedPlanet.cs
+++ b/Valour/Shared/Models/ISharedPlanet.cs
@@ -142,6 +142,14 @@ public interface ISharedPlanet : ISharedModel<long>
     string? Vanity { get; set; }
 
     /// <summary>
+    /// True when the planet's vanity name also works as a permanent invite
+    /// link (/i/{vanity}), letting a memorable name double as a share link
+    /// instead of a random invite code. Only takes effect while Public and
+    /// Vanity are both set.
+    /// </summary>
+    bool VanityInviteEnabled { get; set; }
+
+    /// <summary>
     /// Owner-chosen default cadence for channel activity notifications.
     /// Applies to members who have not set their own cooldown preference.
     /// </summary>


### PR DESCRIPTION
## Summary
Adds a "Use Vanity URL as Invite" toggle to a planet's Invites settings, only shown once Invites Enabled is on. When turned on, `/i/{vanity}` (e.g. `/i/valourcentral`) works as a standing, permanent invite link alongside a planet's regular randomly-generated invite codes — a memorable name instead of a random code, without needing to manage a separate invite entry.

## Changes
- `Planet.VanityInviteEnabled` (bool), plumbed through the Database/Shared/Sdk/Server models and mapper, with a migration
- Server validates the toggle can only be turned on when the planet has a vanity name claimed and Invites are enabled, and auto-clears it if the vanity name is ever removed
- Invite resolution (`/i/{code}` screen + join flow) falls back to checking a planet's vanity name when the code doesn't match a real invite — no client routing changes needed, since the existing invite page and deep-link parsing are already code-agnostic
- The vanity invite shows up in the "Invite Links" list itself (labeled "Vanity URL · Never expires") with its own copy button; its delete button turns the toggle off instead of trying to delete a nonexistent invite row

## Test plan
- [x] Toggle is hidden when Invites Enabled is off, and disabled (with a hint) when no vanity URL is set
- [x] Turning the toggle on with a vanity URL set works, and `/i/{vanity}` resolves and lets someone join
- [x] Turning it off (via the toggle or the invite list's delete button) makes `/i/{vanity}` stop working
- [x] Clearing the planet's vanity URL (Info tab) automatically disables the toggle
- [x] Regular invite codes are unaffected throughout
- [x] Migration applies cleanly to an existing database

## Images

<details>
<summary>Invites Disabled</summary>
<img width="649" height="248" alt="image" src="https://github.com/user-attachments/assets/6e8c7068-6b80-4ea1-95a0-178cc66dd8ff" />
</details>
<details>
<summary>Invites Enabled with VanityURL set</summary>
<img width="651" height="334" alt="image" src="https://github.com/user-attachments/assets/bc4fc6c7-1faf-4a9b-b712-adfefffc4524" />
</details>
<details>
<summary>Invites Enabled without VanityURL set</summary>
<img width="653" height="334" alt="image" src="https://github.com/user-attachments/assets/b45fec9e-716b-4252-8151-9839dda7bb5a" />
</details>
<details>
<summary>Vanity Invite Enabled</summary>
<img width="652" height="349" alt="image" src="https://github.com/user-attachments/assets/cf3f66cf-3efb-4607-81d3-91b4e1a4a74a" />
</details>
<details>
<summary>Vanity Invite in Invite Links</summary>
<img width="660" height="263" alt="image" src="https://github.com/user-attachments/assets/3a0e1a14-5276-40f1-9bd9-85663f03ea8b" />
</details>