### PR TITLE
Let <url> stop a link from auto-embedding

### DIFF
--- a/Valour/Server/Cdn/ProxyHandler.cs
+++ b/Valour/Server/Cdn/ProxyHandler.cs
@@ -74,6 +74,12 @@ public class ProxyHandler
 
         foreach (Match match in urls)
         {
+            // <url> is standard markdown for "link this, but don't embed it" -
+            // it still renders as a normal clickable link, it just shouldn't
+            // also generate a preview card here.
+            if (IsBracketed(url, match))
+                continue;
+
             var attachment = await GetAttachmentFromUrl(match.Value, db);
             if (attachment != null)
             {
@@ -87,6 +93,17 @@ public class ProxyHandler
         }
 
         return attachments;
+    }
+
+    private static bool IsBracketed(string url, Match match)
+    {
+        var start = match.Index - 1;
+        var end = match.Index + match.Length;
+
+        if (start < 0 || end >= url.Length)
+            return false;
+
+        return url[start] == '<' && url[end] == '>';
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Closes #1509. Wrapping a link in angle brackets (`<https://app.valour.gg>`) already renders as a plain clickable link via standard markdown — no code change needed there, Markdig already handles it natively. What didn't work was the server still generating a preview/embed card for that URL regardless. Now it doesn't: a bracketed link is skipped when scanning message content for embeds.

This also sidesteps the underlying complaint in the issue about embeds being unreliable to remove after the fact (missing close button on hover, embed reappearing after refresh) — since the embed is never created at send time for a bracketed link, there's nothing to get stuck.

## Changes
- `ProxyHandler.GetUrlAttachmentsFromContent` now skips embed generation for any URL match immediately preceded by `<` and followed by `>` in the raw message content

## Videos

https://github.com/user-attachments/assets/e08556b9-0f63-4a4c-b114-5abda5da7f11

