### PR TITLE
Hide non-display roles in chat, and fix live role updates

### DIFF
--- a/Valour/Client/Components/MembersList/MemberListComponent.razor
+++ b/Valour/Client/Components/MembersList/MemberListComponent.razor
@@ -253,7 +253,13 @@
                 }
                 case ModelUpdatedEvent<PlanetMember> updated:
                 {
-                    // TODO: handle name / whatever changes
+                    // Gaining/losing a role can move the member to a different
+                    // section - name/avatar-only changes don't need a re-bucket.
+                    if (updated.Changes.On(x => x.RoleMembership))
+                    {
+                        DetermineDisplayedRole(updated.Model);
+                    }
+
                     break;
                 }
                 case ModelRemovedEvent<PlanetMember> deleted:

--- a/Valour/Client/Components/Messages/MessageComponent.razor
+++ b/Valour/Client/Components/Messages/MessageComponent.razor
@@ -866,6 +866,7 @@ else
             if (_member is not null) // There is a chance they were deleted
             {
                 _member.Updated += OnMemberUpdated;
+                _member.Planet.Roles.Changed += OnMemberRoleUpdated;
             }
         }
 
@@ -911,9 +912,11 @@ else
         if (_message?.WebhookId is not null)
             return "App";
 
-        // If there's a member, we use the member's planet role
+        // If there's a member, we use their highest displayed role - roles
+        // without the Display Role permission (e.g. organizational separators)
+        // are skipped, same as the member list.
         if (_member is not null)
-            return _member.PrimaryRole?.Name ?? "Unknown Role";
+            return GetChatDisplayedRole()?.Name ?? "Unknown Role";
 
         if (_user is not null)
         {
@@ -935,9 +938,19 @@ else
         if (_message?.WebhookId is not null)
             return "#fff";
 
-        return _member is not null ? (_member.PrimaryRole?.Color ?? "#fff") :
+        return _member is not null ? (GetChatDisplayedRole()?.Color ?? "#fff") :
             (Client.FriendService.FriendLookup.ContainsKey(ParamData.Message.AuthorUserId) ? "#9ffff1" : "#fff");
     }
+
+    /// <summary>
+    /// The role whose name/color shows next to the author's name in chat.
+    /// Unlike PlanetMember.GetDisplayedRoleAsync (used for things like the
+    /// member list, where having no displayable role is fine - they just sit
+    /// under "Online"), chat always needs to show something, so this falls
+    /// back to the default role when no other role is flagged to display.
+    /// </summary>
+    private PlanetRole GetChatDisplayedRole() =>
+        _member?.GetDisplayedRoleAsync() ?? _member?.Roles.FirstOrDefault(x => x.IsDefault);
 
     public string GetAuthorAvatar()
     {
@@ -1052,9 +1065,9 @@ else
         if (eventData.Changes.On(x => x.RoleMembership))
         {
             render = true;
-            
-            _nameTag = _member.PrimaryRole.Name;
-            _nameColor = _member.PrimaryRole.Color;
+
+            _nameTag = GetAuthorRoleTag();
+            _nameColor = GetAuthorColor();
         }
 
         if (render)
@@ -1062,7 +1075,26 @@ else
             _ = ReRender();
         }
     }
-    
+
+    private void OnMemberRoleUpdated(IModelEvent<PlanetRole> eventData)
+    {
+        // A role's own permissions/color can change (e.g. Display Role getting
+        // toggled) without this member's RoleMembership changing at all, so
+        // OnMemberUpdated alone won't catch it.
+        if (eventData is not ModelUpdatedEvent<PlanetRole> updated)
+            return;
+
+        if (!_member.Roles.Any(x => x.Id == updated.Model.Id))
+            return;
+
+        if (!updated.Changes.On(x => x.Permissions) && !updated.Changes.On(x => x.Color))
+            return;
+
+        _nameTag = GetAuthorRoleTag();
+        _nameColor = GetAuthorColor();
+        _ = ReRender();
+    }
+
     public void CheckMinimal()
     {
         if (_lastMessage != null && _message != null)
@@ -1103,6 +1135,7 @@ else
         if (_member is not null)
         {
             _member.Updated -= OnMemberUpdated;
+            _member.Planet.Roles.Changed -= OnMemberRoleUpdated;
         }
 
         if (_user is not null)

--- a/Valour/Client/Components/Users/UserInfoComponent.razor
+++ b/Valour/Client/Components/Users/UserInfoComponent.razor
@@ -138,6 +138,7 @@
         {
             UserId = Member.UserId;
             Member.Updated += OnMemberUpdate;
+            Member.Planet.Roles.Changed += OnRoleUpdate;
         }
 
         CalculateAll();
@@ -164,6 +165,7 @@
         if (Member is not null)
         {
             Member.Updated -= OnMemberUpdate;
+            Member.Planet.Roles.Changed -= OnRoleUpdate;
         }
     }
 
@@ -298,7 +300,30 @@
             }
         });
     }
-    
+
+    private void OnRoleUpdate(IModelEvent<PlanetRole> eventData)
+    {
+        // A role's own permissions/color can change without this member's
+        // RoleMembership changing at all, so that's not enough on its own -
+        // this is what catches "someone edited a role the member already has".
+        if (eventData is not ModelUpdatedEvent<PlanetRole> updated)
+            return;
+
+        if (!Member.Roles.Any(x => x.Id == updated.Model.Id))
+            return;
+
+        if (!updated.Changes.On(x => x.Permissions) && !updated.Changes.On(x => x.Color))
+            return;
+
+        InvokeAsync(() =>
+        {
+            if (DetermineColorChange())
+            {
+                StateHasChanged();
+            }
+        });
+    }
+
     private async Task ShowProfileAsync(MouseEventArgs e = null)
     {
         double x = e?.ClientX ?? 0;


### PR DESCRIPTION
## Summary
Closes #1479. Rather than adding a new setting, this reuses the existing "Display Role" permission that role admins can already toggle per role. The chat window's role tag next to a username was pulling from a member's raw highest-authority role, completely ignoring that permission — so a separator/organizational role with Display Role turned off would still show up beside people's names in chat, even though it's already correctly hidden in the member list.

While tracking this down, found and fixed two related realtime gaps in the same area: editing a role's own permissions or color (e.g. toggling Display Role) didn't update anyone already looking at a member with that role until a full client reload, and giving or removing someone's role didn't move them between member list sections either — both now update instantly.

## Changes
- `GetAuthorRoleTag()` / `GetAuthorColor()` in `MessageComponent.razor` now go through a `GetChatDisplayedRole()` helper that skips roles without the Display Role permission, same as the member list already does, falling back to the default (`@everyone`) role so chat always shows something
- `UserInfoComponent.razor` and `MessageComponent.razor` both now subscribe to role updates (`Planet.Roles.Changed`) and recompute a member's shown color/tag live when a role they hold has its permissions or color edited
- `MemberListComponent.razor` had a `DetermineDisplayedRole(member)` method that already did the work of moving a member between role sections, but nothing ever called it — the handler for a member's role change was a literal `// TODO` stub. Wired it up so gaining/losing a role now re-buckets the member list live instead of requiring a rejoin

## Test plan
- [x] A role with Display Role disabled no longer shows next to a member's name in chat
- [x] A member with only a hidden role still shows the default role's name/color in chat, not blank or "Unknown Role"
- [x] Giving or removing a role from a member moves them between member list sections live, without leaving and rejoining the planet
- [x] Member list role grouping for someone with no displayable role is unaffected (still no group, sits under Online)
