### PR TITLE
Let moderators edit another member's planet identity

### DIFF
--- a/Valour/Client/Components/Menus/Modals/EditIdentityModal.razor
+++ b/Valour/Client/Components/Menus/Modals/EditIdentityModal.razor
@@ -1,0 +1,22 @@
+@inherits Modal<EditIdentityModal.Params>
+
+<BasicModalLayout Title="@Title" Icon="person-vcard" MaxWidth="500px">
+    <MainArea>
+        <EditIdentity Member="@Data.Member" />
+    </MainArea>
+    <ButtonArea>
+        <div class="basic-modal-buttons">
+            <button @onclick="@Close" class="v-btn">Done</button>
+        </div>
+    </ButtonArea>
+</BasicModalLayout>
+
+@code {
+
+    public class Params
+    {
+        public PlanetMember Member { get; set; }
+    }
+
+    private string Title => $"Edit Identity - {Data.Member.Name}";
+}

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
@@ -1,0 +1,207 @@
+@using System.Net.Http.Headers
+@inject ValourClient Client
+
+<div class="editor-section">
+    <h3 class="editor-section-title">
+        <i class="bi bi-person-vcard"></i>
+        Identity Details
+    </h3>
+
+    <div class="identity-preview">
+        <UserAvatar @key="@_previewAvatarKey" User="@Member.User" Member="@Member" Size="48" ShowState="true" />
+        <div class="preview-copy">
+            <strong>@DisplayName</strong>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <label for="@_nicknameInputId">Nickname</label>
+        <input id="@_nicknameInputId" class="v-input" maxlength="32"
+               placeholder="Use account name" @bind="_nickname" @bind:event="oninput" />
+        <div class="field-help">
+            <p class="helper-text">Leave this empty to use <strong>@Member.User.Name</strong>.</p>
+            <span>@_nickname.Length/32</span>
+        </div>
+    </div>
+
+    <div class="actions">
+        <VButton Variant="primary" OnClick="SaveNicknameAsync" Disabled="@_saving">Save Changes</VButton>
+    </div>
+    <ResultLabel Result="@_nicknameResult" />
+</div>
+
+<div class="editor-section">
+    <h3 class="editor-section-title">
+        <i class="bi bi-image"></i>
+        Planet Avatar
+    </h3>
+
+    <div class="avatar-container">
+        <UserAvatar @key="@_avatarKey" User="@Member.User" Member="@Member" Size="96" />
+        <div class="avatar-info">
+            <div class="avatar-actions">
+                <label for="@_avatarInputId" class="v-btn secondary">
+                    <i class="bi bi-upload"></i><span>Upload Image</span>
+                </label>
+                @if (!string.IsNullOrWhiteSpace(Member.MemberAvatar))
+                {
+                    <VButton Variant="secondary" Icon="arrow-counterclockwise" OnClick="RemoveAvatarAsync" Disabled="@_saving">
+                        Use profile avatar
+                    </VButton>
+                }
+            </div>
+            <p class="helper-text">PNG, JPG, GIF, or WEBP. Square images look best; up to 20 MB.</p>
+            <ResultLabel Result="@_avatarResult" />
+        </div>
+        <div hidden>
+            <InputFile id="@_avatarInputId" accept=".png,.jpg,.jpeg,.gif,.webp" OnChange="LoadAvatarFileAsync" />
+        </div>
+    </div>
+</div>
+
+@code {
+    [CascadingParameter] public ModalRoot ModalRoot { get; set; }
+
+    [Parameter] public PlanetMember Member { get; set; }
+
+    private string _nicknameInputId;
+    private string _avatarInputId;
+    private string _avatarKey;
+    private string _previewAvatarKey;
+
+    private string _nickname = string.Empty;
+    private bool _saving;
+    private ITaskResult _nicknameResult;
+    private ITaskResult _avatarResult;
+
+    private string DisplayName => string.IsNullOrWhiteSpace(_nickname) ? Member.User.Name : _nickname.Trim();
+
+    protected override void OnInitialized()
+    {
+        // Member.Id is already a stable unique value for this component's
+        // lifetime, so it doubles as a cheap DOM id without generating a Guid.
+        _nicknameInputId = $"planet-nickname-{Member.Id}";
+        _avatarInputId = $"planet-avatar-upload-{Member.Id}";
+
+        _nickname = Member.Nickname ?? string.Empty;
+        RefreshAvatarKeys();
+    }
+
+    // AvatarKey only actually changes on upload/remove, so it's cached here
+    // instead of being a getter recomputed on every render (e.g. every
+    // keystroke in the nickname field).
+    private void RefreshAvatarKeys()
+    {
+        _avatarKey = $"{Member.Id}:{Member.MemberAvatar}";
+        _previewAvatarKey = $"preview:{_avatarKey}";
+    }
+
+    private async Task SaveNicknameAsync()
+    {
+        if (_saving)
+            return;
+        _saving = true;
+        var old = Member.Nickname;
+        var updated = _nickname?.Trim() ?? string.Empty;
+        Member.Nickname = updated;
+        _nicknameResult = await Member.UpdateAsync();
+        if (!_nicknameResult.Success)
+        {
+            Member.Nickname = old;
+        }
+        else if (old != updated)
+        {
+            // UpdateAsync() PUTs this same cached member, so by the time the
+            // server's realtime echo comes back the diff sees no change and
+            // never fires Updated for our own client - fire it manually so
+            // the member list and chat name tag update without a reload.
+            var changes = ModelUpdateUtils.ChangeDictPool.Get();
+            changes[nameof(PlanetMember.Nickname)] = new Change<string>(old, updated);
+            Member.InvokeUpdatedEvent(new ModelUpdatedEvent<PlanetMember>(Member, new ModelChange<PlanetMember>(changes)));
+        }
+        _saving = false;
+    }
+
+    private async Task LoadAvatarFileAsync(InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        if (file.Size > 20_971_520)
+        {
+            _avatarResult = TaskResult.FromFailure("Avatar must be 20 MB or smaller.");
+            return;
+        }
+
+        await using var stream = file.OpenReadStream(20_971_520);
+        using var memory = new MemoryStream((int)file.Size);
+        await stream.CopyToAsync(memory);
+        var contentType = file.ContentType;
+        // GetBuffer() avoids ToArray()'s full extra copy of the (up to 20 MB) file.
+        var dataUrl = $"data:{contentType};base64,{Convert.ToBase64String(memory.GetBuffer(), 0, (int)memory.Length)}";
+        ModalRoot.OpenModal<ImageCropperModal>(new ImageCropperModal.ModalParams
+        {
+            ImageDataUrl = dataUrl,
+            AspectRatio = 1d,
+            OutputMimeType = contentType,
+            OnCropped = UploadCroppedAvatarAsync,
+            OnCancel = () => { }
+        });
+    }
+
+    private async Task UploadCroppedAvatarAsync(string dataUrl)
+    {
+        if (!EditProfileComponent.TryDecodeImageDataUrl(dataUrl, out var bytes, out var contentType))
+        {
+            _avatarResult = TaskResult.FromFailure("The cropped image could not be read.");
+            return;
+        }
+
+        _saving = true;
+        using var multipart = new MultipartFormDataContent();
+        using var stream = new StreamContent(new MemoryStream(bytes));
+        stream.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+        multipart.Add(stream, "avatar", "avatar");
+        var response = await Member.Node.PostMultipartDataWithResponse<PlanetMember>(
+            $"upload/memberavatar/{Member.PlanetId}/{Member.Id}", multipart);
+        _avatarResult = response;
+        if (response.Success && response.Data is not null)
+        {
+            Member = response.Data.Sync(Client);
+            RefreshAvatarKeys();
+        }
+        _saving = false;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RemoveAvatarAsync()
+    {
+        if (_saving)
+            return;
+        _saving = true;
+        var old = Member.MemberAvatar;
+        var result = await Member.Node.DeleteAsync($"api/members/{Member.Id}/avatar");
+        if (result.Success)
+        {
+            Member.MemberAvatar = string.Empty;
+            RefreshAvatarKeys();
+
+            if (!string.IsNullOrEmpty(old))
+            {
+                // Same reasoning as SaveNicknameAsync: the realtime echo won't
+                // detect a change against our own pre-mutated cached member.
+                var changes = ModelUpdateUtils.ChangeDictPool.Get();
+                changes[nameof(PlanetMember.MemberAvatar)] = new Change<string>(old, string.Empty);
+                Member.InvokeUpdatedEvent(new ModelUpdatedEvent<PlanetMember>(Member, new ModelChange<PlanetMember>(changes)));
+            }
+
+            // The route returns the updated member as its body, which isn't a
+            // message - DeleteAsync doesn't deserialize it, so show a plain
+            // success message instead of the raw JSON.
+            _avatarResult = TaskResult.FromSuccess("Reverted to the profile avatar.");
+        }
+        else
+        {
+            _avatarResult = result;
+        }
+        _saving = false;
+    }
+}

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
@@ -111,10 +111,10 @@
         }
         else if (old != updated)
         {
-            // UpdateAsync() PUTs this same cached member, so by the time the
-            // server's realtime echo comes back the diff sees no change and
-            // never fires Updated for our own client - fire it manually so
-            // the member list and chat name tag update without a reload.
+            // UpdateAsync() PUTs this same cached member, so by the time
+            // the server's realtime echo comes back the diff sees no change
+            // and never fires Updated for our own client - fire it manually
+            // so the member list and chat name tag update without a reload.
             var changes = ModelUpdateUtils.ChangeDictPool.Get();
             changes[nameof(PlanetMember.Nickname)] = new Change<string>(old, updated);
             Member.InvokeUpdatedEvent(new ModelUpdatedEvent<PlanetMember>(Member, new ModelChange<PlanetMember>(changes)));

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor
@@ -193,9 +193,9 @@
                 Member.InvokeUpdatedEvent(new ModelUpdatedEvent<PlanetMember>(Member, new ModelChange<PlanetMember>(changes)));
             }
 
-            // The route returns the updated member as its body, which isn't a
-            // message - DeleteAsync doesn't deserialize it, so show a plain
-            // success message instead of the raw JSON.
+            // The route returns the updated member as its body,
+            // which isn't a message - DeleteAsync doesn't deserialize it,
+            // so show a plain success message instead of the raw JSON.
             _avatarResult = TaskResult.FromSuccess("Reverted to the profile avatar.");
         }
         else

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditIdentity.razor.css
@@ -1,0 +1,90 @@
+.identity-preview {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--slight-tint);
+    border-radius: var(--radius-md);
+    background-color: var(--main-3);
+}
+
+.preview-copy {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.preview-copy strong {
+    max-width: 24rem;
+    color: var(--font-color);
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.preview-copy span {
+    color: var(--font-alt-color);
+    font-size: var(--font-size-xs);
+}
+
+.field-help {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    color: var(--font-alt-color);
+    font-size: var(--font-size-xs);
+}
+
+.field-help .helper-text {
+    margin-bottom: 0;
+}
+
+.field-help > span {
+    flex: 0 0 auto;
+    margin-top: 0.5rem;
+    font-variant-numeric: tabular-nums;
+}
+
+.avatar-container {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+}
+
+.avatar-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.avatar-actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.avatar-info label {
+    cursor: pointer;
+    margin: 0;
+}
+
+.avatar-info .helper-text {
+    margin: 0;
+}
+
+@media (max-width: 520px) {
+    .avatar-container {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .identity-preview {
+        display: flex;
+    }
+}

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditPlanetIdentityComponent.razor
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditPlanetIdentityComponent.razor
@@ -1,5 +1,3 @@
-@using System.Net.Http.Headers
-@using System.IO
 @inject ValourClient Client
 
 <div class="settings-page identity-settings">
@@ -42,79 +40,16 @@
         }
         else
         {
-            <div class="editor-section">
-                <h3 class="editor-section-title">
-                    <i class="bi bi-person-vcard"></i>
-                    Identity Details
-                </h3>
-
-                <div class="identity-preview">
-                    <UserAvatar @key="@($"preview:{AvatarKey}")" User="@Client.Me" Member="@_member" Size="48" ShowState="true" />
-                    <div class="preview-copy">
-                        <strong>@DisplayName</strong>
-                        <span>Preview in @_selectedPlanet.Name</span>
-                    </div>
-                </div>
-
-                <div class="form-group">
-                    <label for="planet-nickname">Nickname</label>
-                    <input id="planet-nickname" class="v-input" maxlength="32"
-                           placeholder="Use your account name" @bind="_nickname" @bind:event="oninput" />
-                    <div class="field-help">
-                        <p class="helper-text">Leave this empty to use <strong>@Client.Me.Name</strong>.</p>
-                        <span>@_nickname.Length/32</span>
-                    </div>
-                </div>
-
-                <div class="actions">
-                    <VButton Variant="primary" OnClick="SaveNicknameAsync" Disabled="@_saving">Save Changes</VButton>
-                </div>
-                <ResultLabel Result="@_nicknameResult" />
-            </div>
-
-            <div class="editor-section">
-                <h3 class="editor-section-title">
-                    <i class="bi bi-image"></i>
-                    Planet Avatar
-                </h3>
-
-                <div class="avatar-container">
-                    <UserAvatar @key="@AvatarKey" User="@Client.Me" Member="@_member" Size="96" />
-                    <div class="avatar-info">
-                        <label for="planet-avatar-upload" class="v-btn secondary">
-                            <i class="bi bi-upload"></i><span>Upload Image</span>
-                        </label>
-                        @if (!string.IsNullOrWhiteSpace(_member.MemberAvatar))
-                        {
-                            <VButton Variant="secondary" Icon="arrow-counterclockwise" OnClick="RemoveAvatarAsync" Disabled="@_saving">
-                                Use profile avatar
-                            </VButton>
-                        }
-                        <p class="helper-text">PNG, JPG, GIF, or WEBP. Square images look best; up to 20 MB.</p>
-                        <ResultLabel Result="@_avatarResult" />
-                    </div>
-                    <div hidden>
-                        <InputFile id="planet-avatar-upload" accept=".png,.jpg,.jpeg,.gif,.webp" OnChange="LoadAvatarFileAsync" />
-                    </div>
-                </div>
-            </div>
+            <EditIdentity Member="@_member" />
         }
     }
 </div>
 
 @code {
-    [CascadingParameter] public ModalRoot ModalRoot { get; set; }
-
     private List<Planet> _planets = new();
     private Planet _selectedPlanet;
     private PlanetMember _member;
-    private string _nickname = string.Empty;
-    private bool _saving;
-    private ITaskResult _nicknameResult;
-    private ITaskResult _avatarResult;
 
-    private string DisplayName => string.IsNullOrWhiteSpace(_nickname) ? Client.Me.Name : _nickname.Trim();
-    private string AvatarKey => $"{_member?.Id}:{_member?.MemberAvatar}";
     private static bool PlanetSearch(Planet planet, string search) =>
         planet.Name.Contains(search, StringComparison.OrdinalIgnoreCase);
 
@@ -143,78 +78,5 @@
         _member = _selectedPlanet?.MyMember;
         if (_member is null && _selectedPlanet is not null)
             _member = await Client.PlanetService.FetchMemberByUserAsync(Client.Me.Id, _selectedPlanet, true);
-        _nickname = _member?.Nickname ?? string.Empty;
-        _nicknameResult = null;
-        _avatarResult = null;
-    }
-
-    private async Task SaveNicknameAsync()
-    {
-        if (_member is null || _saving)
-            return;
-        _saving = true;
-        var old = _member.Nickname;
-        _member.Nickname = _nickname?.Trim() ?? string.Empty;
-        _nicknameResult = await _member.UpdateAsync();
-        if (!_nicknameResult.Success)
-            _member.Nickname = old;
-        _saving = false;
-    }
-
-    private async Task LoadAvatarFileAsync(InputFileChangeEventArgs args)
-    {
-        var file = args.File;
-        if (file.Size > 20_971_520)
-        {
-            _avatarResult = TaskResult.FromFailure("Avatar must be 20 MB or smaller.");
-            return;
-        }
-
-        await using var stream = file.OpenReadStream(20_971_520);
-        using var memory = new MemoryStream();
-        await stream.CopyToAsync(memory);
-        var contentType = file.ContentType;
-        var dataUrl = $"data:{contentType};base64,{Convert.ToBase64String(memory.ToArray())}";
-        ModalRoot.OpenModal<ImageCropperModal>(new ImageCropperModal.ModalParams
-        {
-            ImageDataUrl = dataUrl,
-            AspectRatio = 1d,
-            OutputMimeType = contentType,
-            OnCropped = UploadCroppedAvatarAsync,
-            OnCancel = () => { }
-        });
-    }
-
-    private async Task UploadCroppedAvatarAsync(string dataUrl)
-    {
-        if (!EditProfileComponent.TryDecodeImageDataUrl(dataUrl, out var bytes, out var contentType))
-        {
-            _avatarResult = TaskResult.FromFailure("The cropped image could not be read.");
-            return;
-        }
-
-        _saving = true;
-        using var multipart = new MultipartFormDataContent();
-        using var stream = new StreamContent(new MemoryStream(bytes));
-        stream.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-        multipart.Add(stream, "avatar", "avatar");
-        var response = await _selectedPlanet.Node.PostMultipartDataWithResponse<PlanetMember>(
-            $"upload/memberavatar/{_selectedPlanet.Id}", multipart);
-        _avatarResult = response;
-        if (response.Success && response.Data is not null)
-            _member = response.Data.Sync(Client);
-        _saving = false;
-        await InvokeAsync(StateHasChanged);
-    }
-
-    private async Task RemoveAvatarAsync()
-    {
-        if (_member is null || _saving)
-            return;
-        _saving = true;
-        _avatarResult = await _selectedPlanet.Node.DeleteAsync($"api/members/{_member.Id}/avatar");
-        if (_avatarResult.Success)
-            _member.MemberAvatar = string.Empty;
-        _saving = false;
     }
 }

--- a/Valour/Client/Components/Menus/Modals/Users/Edit/EditPlanetIdentityComponent.razor.css
+++ b/Valour/Client/Components/Menus/Modals/Users/Edit/EditPlanetIdentityComponent.razor.css
@@ -19,94 +19,10 @@
     white-space: nowrap;
 }
 
-.identity-preview {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.65rem 0.85rem;
-    margin-bottom: 1.5rem;
-    border: 1px solid var(--slight-tint);
-    border-radius: var(--radius-md);
-    background-color: var(--main-3);
-}
-
-.preview-copy {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-}
-
-.preview-copy strong {
-    max-width: 24rem;
-    color: var(--font-color);
-    font-size: var(--font-size-md);
-    font-weight: var(--font-weight-semibold);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.preview-copy span {
-    color: var(--font-alt-color);
-    font-size: var(--font-size-xs);
-}
-
-.field-help {
-    display: flex;
-    justify-content: space-between;
-    gap: 1rem;
-    color: var(--font-alt-color);
-    font-size: var(--font-size-xs);
-}
-
-.field-help .helper-text {
-    margin-bottom: 0;
-}
-
-.field-help > span {
-    flex: 0 0 auto;
-    margin-top: 0.5rem;
-    font-variant-numeric: tabular-nums;
-}
-
-.avatar-container {
-    display: flex;
-    align-items: center;
-    gap: 1.25rem;
-}
-
-.avatar-info {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.5rem;
-    min-width: 0;
-}
-
-.avatar-info label {
-    cursor: pointer;
-    margin: 0;
-}
-
-.avatar-info .helper-text {
-    margin: 0;
-}
-
 .empty-state {
     padding: 2rem;
     color: var(--font-alt-color);
     text-align: center;
     border: 1px dashed var(--slight-tint);
     border-radius: var(--radius-lg);
-}
-
-@media (max-width: 520px) {
-    .avatar-container {
-        flex-direction: column;
-        align-items: flex-start;
-    }
-
-    .identity-preview {
-        display: flex;
-    }
 }

--- a/Valour/Client/ContextMenu/Menus/Member/MemberContextMenu.razor
+++ b/Valour/Client/ContextMenu/Menus/Member/MemberContextMenu.razor
@@ -44,6 +44,13 @@ else
 		<Icon><i class="bi bi-hammer"></i></Icon>
 	</ContextMenuItem>
 }
+@if (_canEditIdentity && !_isSelf)
+{
+	<ContextMenuItem OnClickAsync="@OnClickEditIdentity">
+		<Label>Edit Identity</Label>
+		<Icon><i class="bi bi-person-vcard"></i></Icon>
+	</ContextMenuItem>
+}
 @if (!_isSelf && _isBlocked)
 {
 	<ContextMenuItem OnClickAsync="@OnClickUnblock">
@@ -93,6 +100,7 @@ else if (!_isSelf)
 
 	private bool _canKick;
 	private bool _canBan;
+	private bool _canEditIdentity;
 	private bool _isFriend;
 	private bool _isFriendRequested;
 	private bool _isSelf;
@@ -138,17 +146,18 @@ else if (!_isSelf)
 		_isSelf = member.UserId == Client.Me.Id;
 		_isBlocked = BlockService.IsBlocked(member.UserId);
 
-		(_canKick, _canBan) = GetModerationPermissions(member.Planet?.MyMember);
+		(_canKick, _canBan, _canEditIdentity) = GetModerationPermissions(member.Planet?.MyMember);
 	}
 
-	internal static (bool CanKick, bool CanBan) GetModerationPermissions(PlanetMember? currentMember)
+	internal static (bool CanKick, bool CanBan, bool CanEditIdentity) GetModerationPermissions(PlanetMember? currentMember)
 	{
 		if (currentMember is null)
-			return (false, false);
+			return (false, false, false);
 
 		return (
 			currentMember.HasPermission(PlanetPermissions.Kick),
-			currentMember.HasPermission(PlanetPermissions.Ban));
+			currentMember.HasPermission(PlanetPermissions.Ban),
+			currentMember.HasPermission(PlanetPermissions.ManageIdentity));
 	}
 
 	private async Task OnClickMessage()
@@ -203,6 +212,18 @@ else if (!_isSelf)
 		};
 
 		ModalRoot.OpenModal<BanModal>(data);
+	}
+
+	private async Task OnClickEditIdentity()
+	{
+		await CloseAsync();
+
+		var data = new EditIdentityModal.Params()
+		{
+			Member = Data.Member
+		};
+
+		ModalRoot.OpenModal<EditIdentityModal>(data);
 	}
 
 	private async Task OnClickBlock(BlockType blockType)

--- a/Valour/Sdk/Client/ValourClient.cs
+++ b/Valour/Sdk/Client/ValourClient.cs
@@ -358,8 +358,22 @@ public class ValourClient
         var result =  await PrimaryNode.PostAsync("api/users/me/username", model);
 
         if (result.Success)
+        {
+            var old = Me.Name;
             Me.Name = newUsername;
-        
+
+            if (old != newUsername)
+            {
+                // Pre-mutating our own cached user means the realtime echo of
+                // this change won't detect a diff, so other UI watching
+                // User.Updated (member lists, chat name tags) never fires
+                // for our own client without this - see ClientModel.Sync().
+                var changes = ModelUpdateUtils.ChangeDictPool.Get();
+                changes[nameof(User.Name)] = new Change<string>(old, newUsername);
+                Me.InvokeUpdatedEvent(new ModelUpdatedEvent<User>(Me, new ModelChange<User>(changes)));
+            }
+        }
+
         return result;
     }
     

--- a/Valour/Sdk/Client/ValourClient.cs
+++ b/Valour/Sdk/Client/ValourClient.cs
@@ -364,8 +364,8 @@ public class ValourClient
 
             if (old != newUsername)
             {
-                // Pre-mutating our own cached user means the realtime echo of
-                // this change won't detect a diff, so other UI watching
+                // Pre-mutating our own cached user means the realtime echo
+                // of this change won't detect a diff, so other UI watching
                 // User.Updated (member lists, chat name tags) never fires
                 // for our own client without this - see ClientModel.Sync().
                 var changes = ModelUpdateUtils.ChangeDictPool.Get();

--- a/Valour/Server/Api/Dynamic/PlanetMemberApi.cs
+++ b/Valour/Server/Api/Dynamic/PlanetMemberApi.cs
@@ -109,7 +109,7 @@ public class PlanetMemberApi
         [FromBody] PlanetMember member, 
         long id, 
         PlanetMemberService service,
-        UserService userService)
+        ModerationAuditService moderationAuditService)
     {
         if (member is null)
             return ValourResult.BadRequest("Include member in body.");
@@ -121,9 +121,20 @@ public class PlanetMemberApi
         if (targetMember is null)
             return ValourResult.NotFound("Member not found");
 
-        var selfId = await userService.GetCurrentUserIdAsync();
-        if (selfId != targetMember.UserId)
-            return ValourResult.Forbid("You can only modify your own membership.");
+        var selfMember = await service.GetCurrentAsync(targetMember.PlanetId);
+        if (selfMember is null)
+            return ValourResult.NotPlanetMember();
+
+        // You can always edit your own membership, so we only check permissions
+        // if you are not the same as the target
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            if (!await service.HasPermissionAsync(selfMember, PlanetPermissions.ManageIdentity))
+                return ValourResult.LacksPermission(PlanetPermissions.ManageIdentity);
+
+            if (await service.GetAuthorityAsync(selfMember) <= await service.GetAuthorityAsync(targetMember))
+                return ValourResult.Forbid("The target has equal or higher authority than you.");
+        }
 
         // Prevent mass-assignment by only allowing nickname updates via this endpoint.
         targetMember.Nickname = member.Nickname;
@@ -132,6 +143,17 @@ public class PlanetMemberApi
         if (!result.Success)
             return ValourResult.BadRequest(result.Message);
 
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            await moderationAuditService.LogAsync(
+                targetMember.PlanetId,
+                ModerationActionSource.Manual,
+                ModerationActionType.EditIdentity,
+                actorUserId: selfMember.UserId,
+                targetUserId: targetMember.UserId,
+                targetMemberId: targetMember.Id);
+        }
+        
         return Results.Json(result.Data);
     }
 
@@ -140,16 +162,41 @@ public class PlanetMemberApi
     public static async Task<IResult> DeleteAvatarRouteAsync(
         long id,
         PlanetMemberService service,
-        UserService userService)
+        ModerationAuditService moderationAuditService)
     {
-        var member = await service.GetAsync(id);
-        if (member is null)
+        var targetMember = await service.GetAsync(id);
+        if (targetMember is null)
             return ValourResult.NotFound("Member not found.");
-        if (member.UserId != await userService.GetCurrentUserIdAsync())
-            return ValourResult.Forbid("You can only modify your own planet avatar.");
+
+        var selfMember = await service.GetCurrentAsync(targetMember.PlanetId);
+        if (selfMember is null)
+            return ValourResult.NotPlanetMember();
+
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            if (!await service.HasPermissionAsync(selfMember, PlanetPermissions.ManageIdentity))
+                return ValourResult.LacksPermission(PlanetPermissions.ManageIdentity);
+
+            if (await service.GetAuthorityAsync(selfMember) <= await service.GetAuthorityAsync(targetMember))
+                return ValourResult.Forbid("The target has equal or higher authority than you.");
+        }
 
         var result = await service.UpdateAvatarAsync(id, string.Empty);
-        return result.Success ? Results.Json(result.Data) : ValourResult.BadRequest(result.Message);
+        if (!result.Success)
+            return ValourResult.BadRequest(result.Message);
+
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            await moderationAuditService.LogAsync(
+                targetMember.PlanetId,
+                ModerationActionSource.Manual,
+                ModerationActionType.EditIdentity,
+                actorUserId: selfMember.UserId,
+                targetUserId: targetMember.UserId,
+                targetMemberId: targetMember.Id);
+        }
+
+        return Results.Json(result.Data);
     }
 
     [ValourRoute(HttpVerbs.Delete, "api/members/{id}")]

--- a/Valour/Server/Cdn/Api/UploadApi.cs
+++ b/Valour/Server/Cdn/Api/UploadApi.cs
@@ -12,6 +12,7 @@ using Valour.Shared;
 using Valour.Shared.Authorization;
 using Valour.Shared.Cdn;
 using Valour.Shared.Models;
+using Valour.Shared.Models.Staff;
 using Valour.Shared.Utilities;
 
 namespace Valour.Server.Cdn.Api;
@@ -123,7 +124,7 @@ public class UploadApi
     public static void AddRoutes(WebApplication app)
     {
         app.MapPost("/upload/profile", AvatarImageRoute);
-        app.MapPost("/upload/memberavatar/{planetId}", MemberAvatarImageRoute);
+        app.MapPost("/upload/memberavatar/{planetId}/{memberId}", MemberAvatarImageRoute);
         app.MapPost("/upload/profilebg", ProfileBackgroundImageRoute);
         app.MapPost("/upload/image", ImageRoute);
         app.MapPost("/upload/planet/{planetId}", PlanetImageRoute);
@@ -290,16 +291,33 @@ public class UploadApi
         HttpContext ctx,
         TokenService tokenService,
         PlanetMemberService memberService,
+        ModerationAuditService moderationAuditService,
         CdnBucketService bucketService,
-        long planetId)
+        long planetId,
+        long memberId)
     {
         var authToken = await tokenService.GetCurrentTokenAsync();
         if (authToken is null)
             return ValourResult.InvalidToken();
 
-        var member = await memberService.GetByUserAsync(authToken.UserId, planetId);
-        if (member is null)
+        var targetMember = await memberService.GetAsync(memberId);
+        if (targetMember is null || targetMember.PlanetId != planetId)
+            return ValourResult.NotFound("Member not found.");
+
+        var selfMember = await memberService.GetByUserAsync(authToken.UserId, planetId);
+        if (selfMember is null)
             return ValourResult.NotPlanetMember();
+
+        // You can always edit your own avatar, so we only check permissions
+        // if you are not the same as the target
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            if (!await memberService.HasPermissionAsync(selfMember, PlanetPermissions.ManageIdentity))
+                return ValourResult.LacksPermission(PlanetPermissions.ManageIdentity);
+
+            if (await memberService.GetAuthorityAsync(selfMember) <= await memberService.GetAuthorityAsync(targetMember))
+                return ValourResult.Forbid("The target has equal or higher authority than you.");
+        }
 
         var file = ctx.Request.Form.Files.FirstOrDefault();
         if (file is null)
@@ -315,15 +333,29 @@ public class UploadApi
             file.OpenReadStream());
         HandleExif(image);
 
-        var imageId = $"{planetId}/{authToken.UserId}";
+        var imageId = $"{planetId}/{targetMember.UserId}";
         var upload = await UploadPublicImageVariants(
             bucketService, image, "memberavatars", imageId, AvatarSizes, 0, true, false);
         if (!upload.Success)
             return ValourResult.Problem(upload.Message);
 
         var fullPath = $"{ValourHosts.PublicCdnBaseUrl}/valour-public/{upload.Message}?v={DateTimeOffset.UtcNow.ToUnixTimeSeconds()}";
-        var result = await memberService.UpdateAvatarAsync(member.Id, fullPath);
-        return result.Success ? Results.Json(result.Data) : ValourResult.BadRequest(result.Message);
+        var result = await memberService.UpdateAvatarAsync(targetMember.Id, fullPath);
+        if (!result.Success)
+            return ValourResult.BadRequest(result.Message);
+
+        if (selfMember.UserId != targetMember.UserId)
+        {
+            await moderationAuditService.LogAsync(
+                targetMember.PlanetId,
+                ModerationActionSource.Manual,
+                ModerationActionType.EditIdentity,
+                actorUserId: selfMember.UserId,
+                targetUserId: targetMember.UserId,
+                targetMemberId: targetMember.Id);
+        }
+
+        return Results.Json(result.Data);
     }
     
     public static ImageSize[] ThemeBannerSizes =

--- a/Valour/Shared/Authorization/Permissions.cs
+++ b/Valour/Shared/Authorization/Permissions.cs
@@ -502,6 +502,7 @@ public enum PlanetPermissionsEnum
     Manage,
     Kick,
     Ban,
+    ManageIdentity,
     ViewReports,
     ManageCategories,
     ManageChannels,
@@ -558,6 +559,7 @@ public static class PlanetPermissions
                 Manage,
                 Kick,
                 Ban,
+                ManageIdentity,
                 ViewReports,
                 CreateChannels,
                 ManageRoles,
@@ -626,6 +628,8 @@ public static class PlanetPermissions
 
     // Village Permissions
     public static readonly PlanetPermission ManageVillage = new PlanetPermission(0x800000, "Manage Village", "Allow members to edit the planet's village map, buildings, and village settings.");
+    
+    public static readonly PlanetPermission ManageIdentity = new PlanetPermission(0x1000000, "Manage Identity", "Allow members to edit other members' planet nickname and avatar.");
 }
 
 public enum PermissionState

--- a/Valour/Shared/Models/Staff/ModerationAuditLog.cs
+++ b/Valour/Shared/Models/Staff/ModerationAuditLog.cs
@@ -24,7 +24,8 @@ public enum ModerationActionType
     UnlockThread = 13,
     PinThread = 14,
     UnpinThread = 15,
-    DeleteThreadComment = 16
+    DeleteThreadComment = 16,
+    EditIdentity = 17
 }
 
 public interface ISharedModerationAuditLog : ISharedPlanetModel<long>


### PR DESCRIPTION
## Summary
Closes #1657 - moderators previously had no way to fix an inappropriate Planet Identity (per-planet nickname/avatar) other than telling the user to change it themselves.

- Adds a new **Manage Identity** planet permission. A member with it can edit another member's planet nickname and avatar (including uploading a new image, not just resetting), gated behind the same authority check used for Kick/Ban (can't act on an equal-or-higher-ranked member), and logged to the moderation audit log.
- Surfaced as an **"Edit Identity"** option on the member context menu, hidden on yourself and hidden without the permission.
- Extracted the nickname/avatar editor out of the self-edit Settings page into a shared `EditIdentity.razor` component, reused by both the existing settings page and the new moderator modal, so there's one copy of the save logic instead of two.
- Along the way, fixed a bug where changing your own nickname (or avatar-reset) didn't show up live in the member list or open chat tabs until you closed and reopened them - root cause was the client pre-mutating its own cached copy before the realtime update round-tripped back, so the diff never saw a change for your own client. Same underlying bug also affected the global account username change; fixed that too.
- Also fixed a couple of smaller bugs found while testing: the "reset avatar" action was showing a raw JSON dump instead of a success message, and the moderator modal was missing CSS after the extraction (Blazor's per-component CSS scoping needed the styles to move with the markup).

**Note:** this is my own interpretation of how to handle this - permission shape, authority-check reuse, and the shared-component split were all judgment calls on my end, so if there's a preferred approach or convention I should be following instead, happy to adjust.

## Test plan
- [x] Grant "Manage Identity" to a test role; confirm "Edit Identity" appears on other members' context menu for that role, not on yourself, and not without the permission
- [x] Edit another member's nickname and avatar (upload + "use profile avatar") as a mod; confirm both persist and update live in the member list/chat without a reload
- [x] Confirm a mod can't edit a member with equal/higher role authority
- [x] Confirm moderation audit log gets an entry for mod-initiated edits, but not self-edits
- [x] Confirm self-editing via Settings → Planet Identity still works unchanged, no permission required
- [x] Confirm changing your global username updates live everywhere without a reload
- [x] Confirm Kick/Ban still work normally (adjacent code was touched)