### PR TITLE
Fix context menu boundary handling

### DIFF
--- a/Valour/Client/ContextMenu/ContextMenuBase.razor.css
+++ b/Valour/Client/ContextMenu/ContextMenuBase.razor.css
@@ -5,12 +5,7 @@
     top: 0;
     left: 0;
     z-index: 100000;
-    /* .context is positioned at the raw click coordinates before the JS
-       boundary check in reposition() runs on the next frame. Without this,
-       that first-paint position can extend past the viewport and inflate
-       the page's scrollable area for a frame (see issue #1624). Since this
-       wrapper is exactly viewport-sized, clipping here is equivalent to
-       clipping at the viewport edge. */
+    /* clips the pre-reposition first-paint overflow, see #1624 */
     overflow: hidden;
 }
 

--- a/Valour/Client/ContextMenu/ContextMenuBase.razor.css
+++ b/Valour/Client/ContextMenu/ContextMenuBase.razor.css
@@ -5,6 +5,13 @@
     top: 0;
     left: 0;
     z-index: 100000;
+    /* .context is positioned at the raw click coordinates before the JS
+       boundary check in reposition() runs on the next frame. Without this,
+       that first-paint position can extend past the viewport and inflate
+       the page's scrollable area for a frame (see issue #1624). Since this
+       wrapper is exactly viewport-sized, clipping here is equivalent to
+       clipping at the viewport edge. */
+    overflow: hidden;
 }
 
 .context {

--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -57,11 +57,10 @@ export function reposition(){
     }
     
     // Check the position of submenus. If they overflow the top or right edge
-    // of the screen, shift them down/left with margin to fit. Submenus open
-    // via `left: 100%` of their parent button with no built-in bound (see
-    // ContextSubMenu.razor.css), so on narrow screens or where the .mobile
-    // layout isn't applied they can render partially or fully off-screen
-    // (issue #1622).
+    // of the screen, shift them down/left with margin to fit.
+    // Submenus open leftmost to their parent button with no built-in bound,
+    // so on narrow screens or where the .mobile layout is not applied
+    // they can render partially or fully off-screen. (ContextSubMenu.razor.css; #1622)
     for (let i = 0; i < submenus.length; i++){
         const submenu = submenus[i];
 

--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -56,14 +56,34 @@ export function reposition(){
         posY = windowHeight - height;
     }
     
-    // Check the top position of submenus. If above the screen, shift down with margin to fit.
-    // Use boundingbox to get actual position of the element
+    // Check the position of submenus. If they overflow the top or right edge
+    // of the screen, shift them down/left with margin to fit. Submenus open
+    // via `left: 100%` of their parent button with no built-in bound (see
+    // ContextSubMenu.razor.css), so on narrow screens or where the .mobile
+    // layout isn't applied they can render partially or fully off-screen
+    // (issue #1622).
     for (let i = 0; i < submenus.length; i++){
-        const boundingBox = submenus[i].getBoundingClientRect();
-        const subMenuHeight = submenus[i].offsetHeight;
-        
+        const submenu = submenus[i];
+
+        // Clear any previous correction before measuring, so repeated calls
+        // (e.g. on window resize) compute from the untransformed layout
+        // position instead of compounding on top of the last correction.
+        submenu.style.transform = '';
+        const boundingBox = submenu.getBoundingClientRect();
+
+        let translateX = 0;
+        let translateY = 0;
+
+        if (boundingBox.right > windowWidth){
+            translateX = windowWidth - boundingBox.right - 10;
+        }
+
         if (boundingBox.top < 0){
-            submenus[i].style.transform = `translateY(${Math.abs(boundingBox.top) + 10}px)`;
+            translateY = Math.abs(boundingBox.top) + 10;
+        }
+
+        if (translateX !== 0 || translateY !== 0){
+            submenu.style.transform = `translate(${translateX}px, ${translateY}px)`;
         }
     }
 


### PR DESCRIPTION
## Summary

Two related bugs in the context menu's viewport-boundary logic (`Valour/Client/ContextMenu/`):

**#1624 — context menu breaks window layout near the right/bottom edge**

`.context-wrapper` had no `overflow: hidden`. `.context` is positioned at the raw click coordinates via inline style on the very first render; it only gets clamped to the viewport afterward, when `reposition()` runs in `ContextMenuRoot.OnAfterRenderAsync` (a JS interop call, so at least one frame later). Near the right or bottom edge, that first-paint position can extend past the viewport and inflate the page's scrollable area for a frame — this is what shows up as the whole window layout getting messed up.

`.context-wrapper` is already sized to exactly the viewport (`width: 100vw; height: 100vh`), so clipping at its edges is equivalent to clipping at the viewport edge — this closes the gap with no visible side effect once `reposition()` runs and the menu is back within bounds.

**#1622 — context menu (sub)buttons hang off screen / invisible on some screens**

`reposition()` only checked *vertical* (`top < 0`) overflow for open submenus — there was no horizontal check at all, even though `ContextSubMenu` opens its content via `left: 100%` of the parent button (`ContextSubMenu.razor.css`) with no built-in bound. On a narrow viewport, or anywhere the `.mobile` layout override doesn't apply (e.g. some Android browsers/webviews), a submenu can render partially or fully off the right edge of the screen — matching "hangs off... in some cases they don't show up (the copy menu)".

Added a symmetric right-edge check. Also reset any previous `transform` before measuring `getBoundingClientRect()`, since without that, a submenu corrected once would appear already-in-bounds on the next `reposition()` call (e.g. triggered by a window resize) and the correction would be silently dropped instead of recomputed.

Fixes #1624
Fixes #1622

## Test plan
- [x] `dotnet build Valour.Client.csproj` on `version/0.8.0` — succeeds, same 17 pre-existing warnings as base, 0 errors
- [x] `node --check` on the modified JS file — valid syntax
- Not tested in a live browser in this environment — reasoning verified by tracing the exact CSS/JS involved (`.context-wrapper`, `.context`, `ContextSubMenu.razor.css`'s `left: 100%`, and `reposition()`'s existing vertical-only check) rather than empirical UI testing