### PR TITLE
fix: reply reference lost when editing a message

### DIFF
--- a/Valour/Server/Services/MessageService.cs
+++ b/Valour/Server/Services/MessageService.cs
@@ -401,6 +401,7 @@ public class MessageService
             .Include(x => x.Attachments)
             .Include(x => x.Mentions)
             .Include(x => x.Reactions)
+            .Include(x => x.ReplyToMessage)
             .FirstOrDefaultAsync(x => x.Id == updated.Id);
         if (dbOld is not null)
         {


### PR DESCRIPTION
## Summary
Fixes #1627 — editing a message that has a reply loses the reply reference client-side until a full refresh.

**Root cause:** `MessageService.EditMessageAsync` loads the old message with `.Include(Attachments)`, `.Include(Mentions)`, `.Include(Reactions)` — but not `.Include(ReplyToMessage)`, unlike the four other message queries in this file that do include it. Because of that:

1. `dbOld.ReplyToMessage` is never loaded, so `oldModel = dbOld.ToModel()` maps `ReplyTo` to `null` (via `MessageMapper.ToModel()`'s `ReplyTo = message.ReplyToMessage?.ToModel()`), even though `ReplyToId` is correctly set.
2. `updated.ReplyTo = oldModel.ReplyTo;` carries that `null` onto the edited message.
3. The edited message (with `ReplyTo == null`, `ReplyToId` still set) gets broadcast to clients via `RelayMessageEdit`.
4. Client-side, `ModelStore.HandleChanges` does a per-property overwrite of every field on the cached message from the incoming edit event — including `ReplyTo` — so the previously-displayed reply is wiped from the client's cache.
5. A full refresh re-fetches messages through a path that *does* include `ReplyToMessage`, which is why the reply "comes back" after reload, matching the reporter's observation.

## Fix
Added `.Include(x => x.ReplyToMessage)` to the `dbOld` query in `EditMessageAsync`, matching the other message queries in this file.

## Test plan
- [x] Traced the full path: DB query → `MessageMapper.ToModel()` → `EditMessageAsync` → SignalR `RelayMessageEdit` → client `Message.SyncSubModels()` / `ModelStore.HandleChanges` — confirmed this is the only place in the edit path where `ReplyTo` gets nulled.
- [ ] Couldn't run a full build/manual repro in this environment (the repo pins to a .NET 11 preview SDK not available here) — would appreciate a maintainer or CI double-checking the fix against the repro steps in #1627 (edit a message that has a reply; reply should no longer disappear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)