### PR TITLE
Fix context submenus overflowing past the bottom edge

### DIFF
--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -35,9 +35,6 @@ export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, 
     if (boundingBox.top < 0){
         translateY = Math.abs(boundingBox.top) + margin;
     } else if (boundingBox.bottom > windowHeight){
-        // Submenus anchor via `bottom: -50%` off their parent button
-        // (ContextSubMenu.razor.css), so one near the bottom edge can
-        // open a submenu that extends past the viewport bottom.
         translateY = windowHeight - boundingBox.bottom - margin;
     }
 

--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -21,6 +21,32 @@ export function clearMenu() {
     currentMenu = null;
 }
 
+// Margin kept between a repositioned submenu and the viewport edge.
+const SUBMENU_EDGE_MARGIN = 10;
+
+// Pure geometry helper so the boundary-correction math can be unit tested
+// without a DOM (see Tests/Js/context-menu-reposition.test.mjs).
+export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, margin = SUBMENU_EDGE_MARGIN){
+    let translateX = 0;
+    let translateY = 0;
+
+    if (boundingBox.right > windowWidth){
+        translateX = windowWidth - boundingBox.right - margin;
+    }
+
+    if (boundingBox.top < 0){
+        translateY = Math.abs(boundingBox.top) + margin;
+    } else if (boundingBox.bottom > windowHeight){
+        // Submenus anchor via `bottom: -50%` off their parent button
+        // (ContextSubMenu.razor.css), so a button near the bottom edge
+        // can open a submenu whose content extends past the viewport
+        // bottom. Mirrors the right-edge check above. (#1622)
+        translateY = windowHeight - boundingBox.bottom - margin;
+    }
+
+    return { translateX, translateY };
+}
+
 export function reposition(){
 
     if (!currentMenu)
@@ -70,16 +96,7 @@ export function reposition(){
         submenu.style.transform = '';
         const boundingBox = submenu.getBoundingClientRect();
 
-        let translateX = 0;
-        let translateY = 0;
-
-        if (boundingBox.right > windowWidth){
-            translateX = windowWidth - boundingBox.right - 10;
-        }
-
-        if (boundingBox.top < 0){
-            translateY = Math.abs(boundingBox.top) + 10;
-        }
+        const { translateX, translateY } = computeSubmenuTranslate(boundingBox, windowWidth, windowHeight);
 
         if (translateX !== 0 || translateY !== 0){
             submenu.style.transform = `translate(${translateX}px, ${translateY}px)`;

--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -24,8 +24,6 @@ export function clearMenu() {
 // Margin kept between a repositioned submenu and the viewport edge.
 const SUBMENU_EDGE_MARGIN = 10;
 
-// Pure geometry helper so the boundary-correction math can be unit tested
-// without a DOM (see Tests/Js/context-menu-reposition.test.mjs).
 export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, margin = SUBMENU_EDGE_MARGIN){
     let translateX = 0;
     let translateY = 0;
@@ -38,9 +36,8 @@ export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, 
         translateY = Math.abs(boundingBox.top) + margin;
     } else if (boundingBox.bottom > windowHeight){
         // Submenus anchor via `bottom: -50%` off their parent button
-        // (ContextSubMenu.razor.css), so a button near the bottom edge
-        // can open a submenu whose content extends past the viewport
-        // bottom. Mirrors the right-edge check above. (#1622)
+        // (ContextSubMenu.razor.css), so one near the bottom edge can
+        // open a submenu that extends past the viewport bottom.
         translateY = windowHeight - boundingBox.bottom - margin;
     }
 

--- a/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
+++ b/Valour/Client/ContextMenu/ContextMenuRoot.razor.js
@@ -21,10 +21,7 @@ export function clearMenu() {
     currentMenu = null;
 }
 
-// Margin kept between a repositioned submenu and the viewport edge.
-const SUBMENU_EDGE_MARGIN = 10;
-
-export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, margin = SUBMENU_EDGE_MARGIN){
+export function computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, margin = 10){
     let translateX = 0;
     let translateY = 0;
 

--- a/Valour/Tests/Js/context-menu-reposition.test.mjs
+++ b/Valour/Tests/Js/context-menu-reposition.test.mjs
@@ -1,10 +1,10 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// Context menu submenu boundary correction: computeSubmenuTranslate must
-// keep submenus fully inside the viewport on all four edges, including the
-// bottom edge (#1622 - submenus hang off screen when their parent button
-// is near the bottom, since they anchor via `bottom: -50%`).
+// computeSubmenuTranslate must keep submenus fully inside the viewport on
+// all four edges. Submenus anchor via `bottom: -50%` off their parent
+// button, so one near the bottom edge can open a submenu that extends past
+// the viewport bottom.
 const checks = [];
 const check = (name, actual, expected) => checks.push([name, actual, expected]);
 
@@ -25,7 +25,7 @@ check('3. submenu overflowing the top edge is pushed down by the overflow plus m
   computeSubmenuTranslate({ right: 500, top: -15, bottom: 300 }, windowWidth, windowHeight),
   { translateX: 0, translateY: 25 });
 
-check('4. submenu overflowing the bottom edge is pulled up by the overflow plus margin (#1622)',
+check('4. submenu overflowing the bottom edge is pulled up by the overflow plus margin',
   computeSubmenuTranslate({ right: 500, top: 650, bottom: 760 }, windowWidth, windowHeight),
   { translateX: 0, translateY: -50 });
 

--- a/Valour/Tests/Js/context-menu-reposition.test.mjs
+++ b/Valour/Tests/Js/context-menu-reposition.test.mjs
@@ -1,0 +1,46 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// Context menu submenu boundary correction: computeSubmenuTranslate must
+// keep submenus fully inside the viewport on all four edges, including the
+// bottom edge (#1622 - submenus hang off screen when their parent button
+// is near the bottom, since they anchor via `bottom: -50%`).
+const checks = [];
+const check = (name, actual, expected) => checks.push([name, actual, expected]);
+
+const { computeSubmenuTranslate } = await import('../../Client/ContextMenu/ContextMenuRoot.razor.js');
+
+const windowWidth = 1280;
+const windowHeight = 720;
+
+check('1. submenu fully in bounds gets no correction',
+  computeSubmenuTranslate({ right: 500, top: 100, bottom: 300 }, windowWidth, windowHeight),
+  { translateX: 0, translateY: 0 });
+
+check('2. submenu overflowing the right edge is pulled left by the overflow plus margin',
+  computeSubmenuTranslate({ right: 1300, top: 100, bottom: 300 }, windowWidth, windowHeight),
+  { translateX: -30, translateY: 0 });
+
+check('3. submenu overflowing the top edge is pushed down by the overflow plus margin',
+  computeSubmenuTranslate({ right: 500, top: -15, bottom: 300 }, windowWidth, windowHeight),
+  { translateX: 0, translateY: 25 });
+
+check('4. submenu overflowing the bottom edge is pulled up by the overflow plus margin (#1622)',
+  computeSubmenuTranslate({ right: 500, top: 650, bottom: 760 }, windowWidth, windowHeight),
+  { translateX: 0, translateY: -50 });
+
+check('5. right and bottom overflow are corrected independently at once',
+  computeSubmenuTranslate({ right: 1320, top: 650, bottom: 780 }, windowWidth, windowHeight),
+  { translateX: -50, translateY: -70 });
+
+check('6. top-edge overflow takes precedence over bottom-edge overflow',
+  computeSubmenuTranslate({ right: 500, top: -5, bottom: 900 }, windowWidth, windowHeight),
+  { translateX: 0, translateY: 15 });
+
+check('7. custom margin is honored',
+  computeSubmenuTranslate({ right: 500, top: 100, bottom: 740 }, windowWidth, windowHeight, 0),
+  { translateX: 0, translateY: -20 });
+
+for (const [name, actual, expected] of checks) {
+    test(name, () => assert.deepEqual(actual, expected));
+}

--- a/Valour/Tests/Js/context-menu-reposition.test.mjs
+++ b/Valour/Tests/Js/context-menu-reposition.test.mjs
@@ -1,10 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-// computeSubmenuTranslate must keep submenus fully inside the viewport on
-// all four edges. Submenus anchor via `bottom: -50%` off their parent
-// button, so one near the bottom edge can open a submenu that extends past
-// the viewport bottom.
+// computeSubmenuTranslate must keep submenus fully inside the viewport on all four edges.
+// Submenus anchor via `bottom: -50%` off their parent button, so one
+// near the bottom edge can open a submenu that extends past the viewport bottom.
 const checks = [];
 const check = (name, actual, expected) => checks.push([name, actual, expected]);
 


### PR DESCRIPTION
## Summary
- `#1622` was fixed for the top/right edges in #1662, but submenus anchor via `bottom: -50%` off their parent button (`ContextSubMenu.razor.css`), so a button near the bottom of the viewport can still open a submenu whose content extends past the bottom edge. This adds the missing bottom-edge check, mirroring the existing right-edge and top-edge corrections.
- Extracts the boundary-correction math out of `reposition()` into an exported, pure `computeSubmenuTranslate(boundingBox, windowWidth, windowHeight, margin)` so it can be unit tested without a DOM/browser.

## Test plan
- [x] Added `Valour/Tests/Js/context-menu-reposition.test.mjs` (`node --test`) covering: no correction when in bounds, right-edge overflow, top-edge overflow, the new bottom-edge overflow case, simultaneous right+bottom overflow, top-takes-precedence-over-bottom, and a custom margin.
- [x] `node --test Valour/Tests/Js/*.test.mjs` — all 61 tests pass (54 pre-existing + 7 new).