### PR TITLE
Fix notification navigator not recognizing ChannelActivity notifications

### DIFF
--- a/Valour/Client/Utility/NotificationNavigator.cs
+++ b/Valour/Client/Utility/NotificationNavigator.cs
@@ -57,6 +57,27 @@ public static class NotificationNavigator
         return null;
     }
 
+    /// <summary>
+    /// Notification sources that resolve to a planet channel message and are
+    /// routed by fetching the planet/channel and jumping to SourceId.
+    /// The single source of truth for that routing decision (used by
+    /// NavigateTo's switch and exercised directly by
+    /// NotificationNavigatorTests, since the rest of NavigateTo needs a live
+    /// client/JS runtime to run end-to-end).
+    /// </summary>
+    private static readonly HashSet<NotificationSource> PlanetChannelRouteSources = new()
+    {
+        NotificationSource.PlanetMemberMention,
+        NotificationSource.PlanetRoleMention,
+        NotificationSource.PlanetMemberReply,
+        NotificationSource.PlanetHereMention,
+        NotificationSource.PlanetEveryoneMention,
+        NotificationSource.ChannelActivity,
+    };
+
+    internal static bool IsPlanetChannelRouteSource(NotificationSource source) =>
+        PlanetChannelRouteSources.Contains(source);
+
     public static async Task NavigateTo(Notification notification)
     {
         if (notification?.Client is null)
@@ -71,11 +92,7 @@ public static class NotificationNavigator
         {
             switch (notification.Source)
             {
-                case NotificationSource.PlanetMemberMention:
-                case NotificationSource.PlanetRoleMention:
-                case NotificationSource.PlanetMemberReply:
-                case NotificationSource.PlanetHereMention:
-                case NotificationSource.PlanetEveryoneMention:
+                case var source when IsPlanetChannelRouteSource(source):
                 {
                     var planetId = notification.PlanetId;
                     var channelId = notification.ChannelId;

--- a/Valour/Client/Utility/NotificationNavigator.cs
+++ b/Valour/Client/Utility/NotificationNavigator.cs
@@ -57,14 +57,6 @@ public static class NotificationNavigator
         return null;
     }
 
-    /// <summary>
-    /// Notification sources that resolve to a planet channel message and are
-    /// routed by fetching the planet/channel and jumping to SourceId.
-    /// The single source of truth for that routing decision (used by
-    /// NavigateTo's switch and exercised directly by
-    /// NotificationNavigatorTests, since the rest of NavigateTo needs a live
-    /// client/JS runtime to run end-to-end).
-    /// </summary>
     private static readonly HashSet<NotificationSource> PlanetChannelRouteSources = new()
     {
         NotificationSource.PlanetMemberMention,

--- a/Valour/Tests/Client/NotificationNavigatorTests.cs
+++ b/Valour/Tests/Client/NotificationNavigatorTests.cs
@@ -5,10 +5,6 @@ namespace Valour.Tests.Client;
 
 public class NotificationNavigatorTests
 {
-    // #1665: "xx messages from xx people" activity notifications used Source
-    // = ChannelActivity, which NavigateTo's switch didn't recognize, so
-    // clicking "View" always hit the default case ("This notification
-    // doesn't have a destination.") instead of opening the channel.
     [Theory]
     [InlineData(NotificationSource.ChannelActivity)]
     [InlineData(NotificationSource.PlanetMemberMention)]

--- a/Valour/Tests/Client/NotificationNavigatorTests.cs
+++ b/Valour/Tests/Client/NotificationNavigatorTests.cs
@@ -1,0 +1,38 @@
+using Valour.Client.Utility;
+using Valour.Shared.Models;
+
+namespace Valour.Tests.Client;
+
+public class NotificationNavigatorTests
+{
+    // #1665: "xx messages from xx people" activity notifications used Source
+    // = ChannelActivity, which NavigateTo's switch didn't recognize, so
+    // clicking "View" always hit the default case ("This notification
+    // doesn't have a destination.") instead of opening the channel.
+    [Theory]
+    [InlineData(NotificationSource.ChannelActivity)]
+    [InlineData(NotificationSource.PlanetMemberMention)]
+    [InlineData(NotificationSource.PlanetRoleMention)]
+    [InlineData(NotificationSource.PlanetMemberReply)]
+    [InlineData(NotificationSource.PlanetHereMention)]
+    [InlineData(NotificationSource.PlanetEveryoneMention)]
+    public void IsPlanetChannelRouteSource_ForPlanetChannelSources_ReturnsTrue(NotificationSource source)
+    {
+        Assert.True(NotificationNavigator.IsPlanetChannelRouteSource(source));
+    }
+
+    [Theory]
+    [InlineData(NotificationSource.DirectMention)]
+    [InlineData(NotificationSource.DirectReply)]
+    [InlineData(NotificationSource.DirectMessage)]
+    [InlineData(NotificationSource.ThreadComment)]
+    [InlineData(NotificationSource.ThreadReply)]
+    [InlineData(NotificationSource.FriendRequest)]
+    [InlineData(NotificationSource.FriendRequestAccepted)]
+    [InlineData(NotificationSource.EventReminder)]
+    [InlineData(NotificationSource.Platform)]
+    public void IsPlanetChannelRouteSource_ForNonPlanetChannelSources_ReturnsFalse(NotificationSource source)
+    {
+        Assert.False(NotificationNavigator.IsPlanetChannelRouteSource(source));
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #1665.

Channel activity notifications ("N messages from M people in ...", see `ChannelActivityService.cs`) are created with `Source = NotificationSource.ChannelActivity` and the same `PlanetId`/`ChannelId`/`SourceId`/`ClickUrl` shape as planet mention notifications (`/planetchannels/{planetId}/{channelId}/{messageId}`). `NotificationNavigator.NavigateTo`'s switch never listed `ChannelActivity`, so it always fell through to the `default` case and showed "This notification doesn't have a destination." instead of opening the channel at the triggering message — exactly the "Couldn't Open Notification" report in #1665.

- Adds `NotificationSource.ChannelActivity` to the planet-channel-route case.
- Pulls that case grouping into a single `internal static bool IsPlanetChannelRouteSource(NotificationSource)` predicate, used by the switch itself (`case var source when IsPlanetChannelRouteSource(source):`), so there's one source of truth and it's directly unit-testable without needing a live client/JS runtime for the rest of `NavigateTo`.

## Test plan
- [x] Added `Valour/Tests/Client/NotificationNavigatorTests.cs` — asserts all five existing planet-route sources plus the new `ChannelActivity` route to `true`, and DM/thread/friend/event-reminder/platform sources stay `false`.
- [x] `dotnet build Valour/Tests/Valour.Tests.csproj` — succeeds (no new warnings/errors).
- [x] `dotnet test` filtered to `NotificationNavigatorTests` — 15/15 pass.
- [x] `dotnet test` on the full non-DB-dependent `Valour.Tests.Client` namespace (78 tests) — all pass, no regressions.