### PR TITLE
Raise .NET 11 version from Preview 3 to RC 1

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -113,11 +113,8 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        # Pinned to the same SDK as the Dockerfile (preview.3). Floating to the
-        # latest 11.0 preview broke the build: preview.6's static-web-asset
-        # compression discovery chokes on the checked-in TypeScript outputs
-        # (duplicate key on wwwroot/ts/*.js). Bump together with the Dockerfile.
-        dotnet-version: 11.0.100-preview.3.26207.106
+        # Pinned to the same SDK as the Dockerfile. Bump together with the Dockerfile.
+        dotnet-version: 11.0.100-rc.1
 
     - name: Restore workload
       run: dotnet workload restore Valour/Valour.sln

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ transfer limits and the distinction between a pending and completed handoff.
 
 ## Contribute
 
-Install the exact SDK in [global.json](global.json):
-`11.0.100-preview.3.26207.106`. SDK roll-forward is disabled. Local server work also
-requires PostgreSQL and Redis. JavaScript tests use Node.js, and browser tests
-require Playwright. Native application builds require their platform workloads.
+Install the at least the suggested SDK version in [global.json](global.json):
+`11.0.100-rc.1`. Local server work also requires PostgreSQL and Redis.
+JavaScript tests use Node.js, and browser tests require Playwright.
+Native application builds require their platform workloads.
 
 Restore dependencies from the repository root:
 

--- a/Valour/Web/cf-build
+++ b/Valour/Web/cf-build
@@ -2,7 +2,7 @@
 set -eu
 
 # Match the SDK pinned for the rest of the monorepo in ../../global.json.
-DOTNET_VERSION="${VALOUR_WEB_DOTNET_VERSION:-11.0.100-preview.3.26207.106}"
+DOTNET_VERSION="${VALOUR_WEB_DOTNET_VERSION:-11.0.100-rc.1}"
 DOTNET_INSTALL_DIR="${PWD}/.dotnet-pages"
 INSTALL_SCRIPT="$(mktemp)"
 OUTPUT_DIR="dist"

--- a/cf-build
+++ b/cf-build
@@ -6,7 +6,7 @@ python3 Tools/Villages/restore-release-assets.py
 # Install the .NET 11 preview SDK pinned by global.json
 curl -sSL https://dot.net/v1/dotnet-install.sh > dotnet-install.sh
 chmod +x dotnet-install.sh
-./dotnet-install.sh --version 11.0.100-preview.3.26207.106 -InstallDir ./dotnet
+./dotnet-install.sh --version 11.0.100-rc.1 -InstallDir ./dotnet
 export PATH="$PWD/dotnet:$PATH"
 dotnet --version
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,11 +1,11 @@
-# Start with the official .NET 11 preview SDK image
+# Start with the official .NET 11 RC 1 SDK image
 # Cache the dependencies so we don't have to restore them every time
 #
 # --platform=$BUILDPLATFORM: the build stages always run natively on the build
 # host and cross-publish for $TARGETARCH (see the publish step below). Emulating
 # the full .NET publish under QEMU is slow and unreliable, so multi-arch images
 # only emulate the final runtime stage, which runs nothing at build time.
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-preview.3 AS dependencies
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:11.0.100-rc.1 AS dependencies
 
 # Install Node.js (needed for the TypeScript compile during publish) from the
 # official dist tarballs. The NodeSource apt script broke when the SDK image

--- a/global.json
+++ b/global.json
@@ -1,7 +1,6 @@
 {
   "sdk": {
-    "version": "11.0.100-preview.3.26207.106",
-    "rollForward": "disable",
+    "version": "11.0.100-rc.1",
     "allowPrerelease": true
   }
 }


### PR DESCRIPTION
.NET 11 release is closer, we might be interested to upgrade from preview version to Go Live eligible one.

Will also test CI.